### PR TITLE
Add a try catch for when a lib has no tags

### DIFF
--- a/Sources/MintKit/MintKit.swift
+++ b/Sources/MintKit/MintKit.swift
@@ -103,11 +103,13 @@ public struct Mint {
         try shellOut(to: "git fetch --tags", at: package.checkoutPath.string)
 
         if package.version.isEmpty {
-            let tag = try shellOut(to: "git describe --abbrev=0 --tags", at: package.checkoutPath.string)
-            if !tag.isEmpty {
+            do {
+                // This will exit with a non-zero status code when there are no tags
+                let tag = try shellOut(to: "git describe --abbrev=0 --tags", at:  package.checkoutPath.string)
+
                 package.version = tag
                 print("🌱  Using latest tag \(tag.quoted)")
-            } else {
+            }  catch {
                 package.version = "master"
                 print("🌱  Using branch \(package.version.quoted)")
             }


### PR DESCRIPTION
I was getting a pretty mysterious error:

<img width="416" alt="screen shot 2017-10-02 at 10 20 26 pm" src="https://user-images.githubusercontent.com/49038/31107366-ee606fbe-a7bf-11e7-8bd8-0a0ea6bd354d.png">

So I opened it in Xcode and attached a breakpoint to Swift errors. Turns out that the git command to get the latest tag will fail instead of giving no output

<img width="406" alt="screen shot 2017-10-02 at 10 12 07 pm" src="https://user-images.githubusercontent.com/49038/31107387-17101f18-a7c0-11e7-97df-2d4c920171a1.png">

So this handles that.