### PR TITLE
Change version to an @ suffix to the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 A package manager that installs and runs Swift command line tool packages.
 
 ```sh
-$ mint run realm/swiftlint 0.22.0
+$ mint run realm/swiftlint@0.22.0
 ```
 This would install and run [SwiftLint](https://github.com/realm/SwiftLint) version 0.22.0
 
@@ -88,18 +88,18 @@ Use "mint [command] --help" for more information about a command.
 - **Run**: Runs a package. This will install if first if it doesn't exist
 - **Update**: Installs a package while enforcing an update and rebuild. Shouldn't be required unless you are pointing at a branch and want to update.
 
-These commands all have 1 to 3 arguments:
+These commands all have 1 or 2 arguments:
 
-- **repo (required)**: This can be a shorthand for a github repo `install realm/SwiftLint` or a fully qualified git path `install https://github.com/realm/SwiftLint.git`. In the case of `run` you can also just pass the name of the repo if it is already installed `run swiftlint`. This will do a lookup of all installed packages.
-- **version (optional)**: The git version of the packge. It is usually a tag but can also be a branch. If this is left out the version will default to the latest tag, or if there are no tags then master.
-- **command (optional)**: The command to install or run. This defaults to the the last path in the repo (so for `realm/swiftlint` it will be `swiftlint`). In the case of `run` you can also pass any arguments to the command but make sure the whole thing is surrounded by quotes eg `mint run realm/swiftlint 0.22.0 "swiftlint --path source"`
+- **repo (required)**: This can be a shorthand for a github repo `install realm/SwiftLint` or a fully qualified git path `install https://github.com/realm/SwiftLint.git`. In the case of `run` you can also just pass the name of the repo if it is already installed `run swiftlint`. This will do a lookup of all installed packages. An optional version can be specified by appending `@version`, otherwise the newest tag or master will be used.
+- **command (optional)**: The command to install or run. This defaults to the the last path in the repo (so for `realm/swiftlint` it will be `swiftlint`). In the case of `run` you can also pass any arguments to the command but make sure the whole thing is surrounded by quotes eg `mint run realm/swiftlint "swiftlint --path source"`
+
 
 #### Examples
 ```sh
-$ mint install yonaskolb/xcodegen 1.2.0 "xcodegen --spec spec.yml" # pass some arguments
-$ mint install yonaskolb/xcodegen 1.2.0 # use version 1.2.0
+$ mint install yonaskolb/xcodegen@1.2.4 "xcodegen --spec spec.yml" # pass some arguments
+$ mint install yonaskolb/xcodegen@1.2.4 # use version 1.2.4
 $ mint install yonaskolb/xcodegen # use newest tag
-$ mint run yonaskolb/xcodegen 1.2.0 # run 1.2.0
+$ mint run yonaskolb/xcodegen@1.2.4 # run 1.2.4
 $ mint run xcodegen # use newest tag and find xcodegen in installed tools
 ```
 

--- a/Sources/Mint/main.swift
+++ b/Sources/Mint/main.swift
@@ -26,15 +26,15 @@ func catchError(closure: () throws -> ()) {
 
 enum CommandError: Error, CustomStringConvertible {
     case repoRequired
-    case commandNotParsed
+    case invalidRepo(String)
     case tooManyArguments
 
     var description: String {
         switch self {
         case .repoRequired:
             return "Repo required"
-        case .commandNotParsed:
-            return "Version and command couldn't be automatically parsed. Please pass \"\" for version"
+        case .invalidRepo(let repo):
+            return "The repo was invalid: \(repo)"
         case .tooManyArguments:
             return "Too many arguments. Make sure command is surrounded in quotes"
         }
@@ -42,31 +42,28 @@ enum CommandError: Error, CustomStringConvertible {
 }
 
 func getOptions(flags: Flags, args: [String]) throws -> (repo: String, version: String, command: String) {
-    guard let repo = args.first else { throw CommandError.repoRequired }
-    var version: String = ""
+    guard let repoVersion = args.first else { throw CommandError.repoRequired }
+    let version: String
     let command: String
-    let extractedCommand = repo.components(separatedBy: "/").last!.components(separatedBy: ".").first!.lowercased()
+    let repoVersionParts = repoVersion.components(separatedBy: "@")
+    let repo: String
+
+    switch repoVersionParts.count {
+    case 2:
+        repo = repoVersionParts[0]
+        version = repoVersionParts[1]
+    case 1:
+        repo = repoVersion
+        version = ""
+    default:
+        throw CommandError.invalidRepo(repoVersion)
+    }
 
     switch args.count {
-    case 3:
-        version = args[1]
-        command = args[2]
     case 2:
-        let argument = args[1]
-        let string = argument.components(separatedBy: " ").first!
-        if string == extractedCommand {
-            // string is a command
-            command = argument
-            version = ""
-        } else if string.contains(".") || string == "master" {
-            // string is version
-            version = string
-            command = extractedCommand
-        } else {
-            throw CommandError.commandNotParsed
-        }
+        command = args[1]
     case 1:
-        command = extractedCommand
+        command = repo.components(separatedBy: "/").last!.components(separatedBy: ".").first!.lowercased()
     default:
         throw CommandError.tooManyArguments
     }
@@ -79,11 +76,11 @@ command.run = { _, _  in
 }
 
 let commandHelp = """
-This command takes between 1 and 3 arguments: repo, version and command.
+This command takes allows you to specify a repo, a version and an executable command to run.
 
-- You must pass a repo either in the shorthand for of a github repo \"githubName/repo\", or a fully qualified .git path.
-- An optional version can be passed, otherwise the newest tag or master will be used.
-- An optional command qualifies the command name, otherwise this will be assumed to the be the end of the repo name.
+- Repo is either in shorthand for a github repo \"githubName/repo\", or a fully qualified .git path.
+- An optional version can be specified by appending @version to the repo, otherwise the newest tag or master will be used.
+- The second argument qualifies the command name, otherwise this will be assumed to the be the end of the repo name.
 """
 
 let runCommand = Command(usage: "run repo (version) (command)", shortMessage: "Run a package", longMessage: "This will run a package tool. If it isn't installed if will do so first.\n\(commandHelp) The command can include any arguments and flags but the whole command must then be surrounded in quotes.", example: "mint run realm/swiftlint 0.22.0") { flags, args in


### PR DESCRIPTION
This changes
```
$ mint run realm/swiftlint 0.22.0
```
to:
```
$ mint run realm/swiftlint@0.22.0
```
This also removes the guessing of what the second argument is as at it will always be the executable command