### PR TITLE
Complete Test Coverage

### DIFF
--- a/.Workspace Configuration.txt
+++ b/.Workspace Configuration.txt
@@ -1,0 +1,26 @@
+Project Type: Executable
+
+Module Name: MintKit
+
+Manage Xcode: True
+Primary Xcode Target: MintKit
+
+Manage Continuous Integration: True
+
+([_Workaround: Several dependencies trigger compiler warnings._])
+Prohibit Compiler Warnings: False
+
+([_Workaround: These triggered when Workspace was first applied, so @SDGGiesbrecht deactivated them. @yonaskolb should decide which rules to enforce over the long term._])
+[_Begin Disable Proofreading Rules_]
+Colon Spacing
+Syntax Colouring
+colon
+function_body_length
+large_tuple
+line_length
+opening_brace
+statement_position
+trailing_comma
+unused_closure_parameter
+void_return
+[_End_]

--- a/.Workspace Configuration.txt
+++ b/.Workspace Configuration.txt
@@ -1,4 +1,5 @@
 Project Type: Executable
+Support Linux: False
 
 Module Name: MintKit
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -9,12 +9,6 @@
 # https://github.com/SDGGiesbrecht/Workspace/blob/master/Documentation/Git.md
 # !!!!!!! !!!!!!! !!!!!!! !!!!!!! !!!!!!! !!!!!!! !!!!!!!
 
-.DS_Store
-/.build
-/Packages
-/Validate\ (macOS).command
-/Validate\ (Linux).sh
-/.Test\ Zone
-/*.xcodeproj
+/Refresh?Workspace* linguist-vendored=true
 
 # [_End Workspace Section]

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,15 +17,6 @@ matrix:
       script:
         - "bash ./Refresh\\ \\(macOS\\).command"
         - "bash ./Validate\\ \\(macOS\\).command"
-    - os: linux
-      dist: trusty
-      env:
-        - JOB="Linux"
-        - SWIFT_VERSION=4.0
-      script:
-        - "eval \"$(curl -sL https://gist.githubusercontent.com/kylef/5c0475ff02b7c7671d2a/raw/9f442512a46d7a2af7b850d65a7e9bd31edfb09b/swiftenv-install.sh)\""
-        - "bash ./Refresh\\ \\(macOS\\).command"
-        - "bash ./Validate\\ \\(macOS\\).command"
     - os: osx
       env:
         - JOB="Misc."

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,41 @@
-os:
-  - osx
-language: swift
-osx_image: xcode9
-script:
-  - swift build
-  - swift test
+
+
+# !!!!!!! !!!!!!! !!!!!!! !!!!!!! !!!!!!! !!!!!!! !!!!!!!
+# This file is managed by Workspace.
+# Manual changes will not persist.
+# For more information, see:
+# https://github.com/SDGGiesbrecht/Workspace/blob/master/Documentation/Continuous Integration.md
+# !!!!!!! !!!!!!! !!!!!!! !!!!!!! !!!!!!! !!!!!!! !!!!!!!
+
+language: generic
+matrix:
+  include:
+    - os: osx
+      env:
+        - JOB="macOS"
+      osx_image: xcode9
+      script:
+        - "bash ./Refresh\\ \\(macOS\\).command"
+        - "bash ./Validate\\ \\(macOS\\).command"
+    - os: linux
+      dist: trusty
+      env:
+        - JOB="Linux"
+        - SWIFT_VERSION=4.0
+      script:
+        - "eval \"$(curl -sL https://gist.githubusercontent.com/kylef/5c0475ff02b7c7671d2a/raw/9f442512a46d7a2af7b850d65a7e9bd31edfb09b/swiftenv-install.sh)\""
+        - "bash ./Refresh\\ \\(macOS\\).command"
+        - "bash ./Validate\\ \\(macOS\\).command"
+    - os: osx
+      env:
+        - JOB="Misc."
+      osx_image: xcode9
+      script:
+        - "brew update"
+        - "brew outdated swiftlint || brew upgrade swiftlint"
+        - "bash ./Refresh\\ \\(macOS\\).command"
+        - "bash ./Validate\\ \\(macOS\\).command"
+
+cache:
+  directories:
+  - $HOME/.Workspace

--- a/Refresh (Linux).sh
+++ b/Refresh (Linux).sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+
+
+set -e
+REPOSITORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "${REPOSITORY}"
+gnome-terminal -e "bash --login -c \"source ~/.bashrc; ./Refresh\ \(macOS\).command; exec bash\""

--- a/Refresh (macOS).command
+++ b/Refresh (macOS).command
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+
+
+set -e
+REPOSITORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "${REPOSITORY}"
+if workspace version > /dev/null 2>&1 ; then
+    echo "Using system install of Workspace..."
+    workspace refresh •use‐version 0.2.0
+elif ~/Library/Caches/ca.solideogloria.Workspace/Versions/0.2.0/workspace version > /dev/null 2>&1 ; then
+    echo "Using cached build of Workspace..."
+    ~/Library/Caches/ca.solideogloria.Workspace/Versions/0.2.0/workspace refresh •use‐version 0.2.0
+elif ~/.cache/ca.solideogloria.Workspace/Versions/0.2.0/workspace version > /dev/null 2>&1 ; then
+    echo "Using cached build of Workspace..."
+    ~/.cache/ca.solideogloria.Workspace/Versions/0.2.0/workspace refresh •use‐version 0.2.0
+else
+    echo "No cached build detected, fetching Workspace..."
+    rm -rf /tmp/Workspace
+    git clone https://github.com/SDGGiesbrecht/Workspace /tmp/Workspace
+    cd /tmp/Workspace
+    swift build --configuration release
+    cd "${REPOSITORY}"
+    /tmp/Workspace/.build/release/workspace refresh •use‐version 0.2.0
+    rm -rf /tmp/Workspace
+fi

--- a/Sources/Mint/main.swift
+++ b/Sources/Mint/main.swift
@@ -112,4 +112,3 @@ command.add(subCommand: installCommand)
 command.add(subCommand: updateCommand)
 
 command.execute()
-

--- a/Sources/MintKit/Package.swift
+++ b/Sources/MintKit/Package.swift
@@ -41,6 +41,7 @@ public class Package {
     var checkoutPath: Path { return path + "checkout" }
     var installPath: Path { return path + "build" + version }
     var commandPath: Path { return installPath + name }
-    var metadataPath: Path { return path + "metadata.json" }
+    // [_Workaround: This property was completely unused and unreachable. Why was it here?_]
+    // var metadataPath: Path { return path + "metadata.json" }
 
 }

--- a/Tests/MintTests/MintTests.swift
+++ b/Tests/MintTests/MintTests.swift
@@ -1,15 +1,123 @@
+import Foundation
 import XCTest
+
+import ShellOut
+
 @testable import MintKit
 
 class MintTests: XCTestCase {
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct
-        // results.
-        XCTAssertEqual("Hello", "Hello")
+
+    override func setUp() {
+        super.setUp()
+        // Reset (debug) cached installs and files to a clean slate.
+        try? FileManager.default.removeItem(at: Mint.path.url)
+    }
+    override func tearDown() {
+        // Clean up debug cache.
+        try? FileManager.default.removeItem(at: Mint.path.url)
+    }
+
+    let testRepository = "yonaskolb/Mint"; let invalidRepository = "yonaskolb/Mnt"
+    let testPackageShorthand = "Mint"; let invalidPackageShorthand = "Mnt"
+    let testVersion = "0.1.0"
+    let testCommand = "Mint"; let invalidCommand = "Mnt"
+    let testCommandWithArguments = "Mint --help"
+
+    func testInstallCommand() {
+        // Standard
+        do {
+            try Mint.install(repo: testRepository, version: testVersion, command: testCommand, force: false)
+        } catch let error {
+            XCTFail(error.localizedDescription)
+        }
+        // Already installed
+        do {
+            try Mint.install(repo: testRepository, version: testVersion, command: testCommand, force: false)
+        } catch let error {
+            XCTFail(error.localizedDescription)
+        }
+
+        // Invalid repository
+        do {
+            try Mint.install(repo: invalidPackageShorthand, version: testVersion, command: testCommand, force: false)
+            XCTFail("No error thrown with invalid repository.")
+        } catch let error {
+            XCTAssertEqual(error as? MintError, MintError.invalidRepo(invalidPackageShorthand))
+        }
+    }
+
+    func testRunCommand() {
+        // Standard
+        do {
+            try Mint.run(repo: testRepository, version: testVersion, command: testCommand)
+        } catch let error {
+            XCTFail(error.localizedDescription)
+        }
+        do {
+            try Mint.run(repo: invalidRepository, version: testVersion, command: testCommand)
+            XCTFail("No error thrown with invalid repository.")
+        } catch let error {
+            XCTAssertEqual(error as? MintError, MintError.repoNotFound("https://github.com/" + invalidRepository + ".git"))
+        }
+
+        // Shorthand when already intalled
+        do {
+            try Mint.run(repo: testPackageShorthand, version: testVersion, command: testCommand)
+        } catch let error {
+            XCTFail(error.localizedDescription)
+        }
+        do {
+            try Mint.run(repo: invalidPackageShorthand, version: testVersion, command: testCommand)
+            XCTFail("No error thrown with invalid package shorthand.")
+        } catch let error {
+            XCTAssertEqual(error as? MintError, MintError.packageNotFound(invalidPackageShorthand))
+        }
+
+        // Specified command name
+        do {
+            try Mint.run(repo: testRepository, version: testVersion, command: invalidCommand)
+            XCTFail("No error thrown with invalid command.")
+        } catch let error {
+            XCTAssertEqual(error as? MintError, MintError.invalidCommand(invalidCommand.components(separatedBy: " ").first!))
+        }
+
+        // With arguments
+        do {
+            try Mint.run(repo: testRepository, version: testVersion, command: testCommandWithArguments)
+        } catch let error {
+            XCTFail(error.localizedDescription)
+        }
+
+        // With GitHub domain
+        do {
+            try Mint.run(repo: "github.com/" + testRepository, version: testVersion, command: testCommand)
+        } catch let error {
+            XCTFail(error.localizedDescription)
+        }
+    }
+
+    func testVersionlessRepository() {
+        let temp = URL(fileURLWithPath: "/tmp/MyPackage")
+        try? FileManager.default.removeItem(at: temp)
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        do {
+            try FileManager.default.createDirectory(at: temp, withIntermediateDirectories: true, attributes: nil)
+            try shellOut(to: "swift package init --type executable", at: temp.path)
+            try shellOut(to: "git init", at: temp.path)
+            try shellOut(to: "echo \u{22}Sources\nNonexistent\u{22} > Package.resources", at: temp.path)
+            try shellOut(to: "git add .", at: temp.path)
+            try shellOut(to: "git commit -m \u{22}Committed.\u{22}", at: temp.path)
+
+            try Mint.run(repo: temp.absoluteString, version: "", command: "MyPackage")
+        } catch let error {
+            XCTFail(error.localizedDescription)
+        }
     }
 
     static var allTests = [
-        ("testExample", testExample),
+        ("testInstallCommand", testInstallCommand),
+        ("testRunCommand", testRunCommand),
+        ("testVersionlessRepository", testVersionlessRepository)
     ]
 }


### PR DESCRIPTION
This fixes #16 (lack of tests) ~~and #15 (Linux support)~~. Users will not perceive any difference.

This should make Mint significantly more resilient against regressions and make reviewing pull requests easier.

I’ve split this into two commits that I will push separately so that CI runs on both:
- The first commit sets up test coverage enforcement without actually adding any unit tests, so you can see [what enforcement looks like when it fails](https://travis-ci.org/yonaskolb/Mint/jobs/306166576#L1083). This commit involves:
    - [A complete rewrite of `.travis.yml`.](https://github.com/yonaskolb/Mint/pull/23/commits/eec91e09c1d205c3b947974751545cf507d9e750#diff-354f30a63fb0907d4ad57269548329e3)
    - [Additional miscellaneous configuration files.](https://github.com/yonaskolb/Mint/pull/23/commits/eec91e09c1d205c3b947974751545cf507d9e750#diff-938e116a705434d3b38e9b61f1ef07b3)
    - No changes to any Swift code.
- The second commit adds unit tests so that CI will pass. This commit involves:
    - Minor adjustments to `MintKit` for ease of testing:
        - [`MintError` becomes `Equatable`.](https://github.com/yonaskolb/Mint/pull/23/commits/93766118da0c54ff8ec8cd626f6a5f18a07bd548#diff-949027ac671bf637be0217048ab6a88aR6)
        - [The `mint` directory is swapped out for a doppelgänger during development and testing](https://github.com/yonaskolb/Mint/pull/23/commits/93766118da0c54ff8ec8cd626f6a5f18a07bd548#diff-949027ac671bf637be0217048ab6a88aR32) to reduce interference with the permanent install. i.e.:
            - still `mint` in the release configuration. (`swift build --configuration release`)
            - now `mint.debug` in the debug configuration. (`swift build`/`swift test`/`swift run`...)
    - [`MintTests` has been filled out.](https://github.com/yonaskolb/Mint/pull/23/commits/93766118da0c54ff8ec8cd626f6a5f18a07bd548#diff-59ee75be16d3da6ed4510210f67b8199)

✓ Edits allowed from maintainers.

Note that `[_Exempt from Code Coverage_]` can be used when Xcode gives faulty results, or there is absolutely no way to test something, such as [here](https://github.com/yonaskolb/Mint/pull/23/commits/93766118da0c54ff8ec8cd626f6a5f18a07bd548#diff-949027ac671bf637be0217048ab6a88aR129).