### PR TITLE
Change git fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Fixed issues on case‐sensitive file systems #19 @SDGGiesbrecht
 - Fixed updating branches and packages without checked in `Package.resolved` files #24
 - Package repos are now checked out fresh on each install #24
+- If not passing a version, tags are now fetched remotely #24
+- Clones are now shallow #28
 - Added `mint list` command for listing all installed package versions #25
 - Added `mint --version` #27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 ## Master
 
-- Mint is now compatible with case‐sensitive file systems.
+## 0.6.0
+
+- Fixed issues on case‐sensitive file systems #19 @SDGGiesbrecht
+- Fixed updating branches and packages without checked in `Package.resolved` files #24
+- Package repos are now checked out fresh on each install #24
+- Added `mint list` command for listing all installed package versions #25
+- Added `mint --version` #27
+
+[Commits](https://github.com/yonaskolb/XcodeGen/compare/0.5.0...0.6.0)
 
 ## 0.5.0
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Use "mint [command] --help" for more information about a command.
 
 These commands all have 1 or 2 arguments:
 
-- **repo (required)**: This can be a shorthand for a github repo `install realm/SwiftLint` or a fully qualified git path `install https://github.com/realm/SwiftLint.git`. In the case of `run` you can also just pass the name of the repo if it is already installed `run swiftlint`. This will do a lookup of all installed packages. An optional version can be specified by appending `@version`, otherwise the newest tag or master will be used.
+- **repo (required)**: This can be a shorthand for a github repo `install realm/SwiftLint` or a fully qualified git path `install https://github.com/realm/SwiftLint.git`. In the case of `run` you can also just pass the name of the repo if it is already installed `run swiftlint`. This will do a lookup of all installed packages. An optional version can be specified by appending `@version`, otherwise the newest tag or master will be used. Note that if you don't specify a version, the current tags must be loaded remotely each time.
 - **command (optional)**: The command to install or run. This defaults to the the last path in the repo (so for `realm/swiftlint` it will be `swiftlint`). In the case of `run` you can also pass any arguments to the command but make sure the whole thing is surrounded by quotes eg `mint run realm/swiftlint "swiftlint --path source"`
 
 


### PR DESCRIPTION
- latest tag is now retrieved with `git ls-remote --tags` before a clone if no version is specified
- git clone is now shallow