### PR TITLE
Use SwiftPM to sort tags

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -54,6 +54,15 @@
           "revision": "246c697efe2f57d9042f58b1b53ace4fddb1efc4",
           "version": "0.2.0"
         }
+      },
+      {
+        "package": "SwiftPM",
+        "repositoryURL": "https://github.com/apple/swift-package-manager.git",
+        "state": {
+          "branch": null,
+          "revision": "90abb3c4c9415afee34291e66e655c58a1902784",
+          "version": "0.1.0"
+        }
       }
     ]
   },

--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,7 @@ let package = Package(
         .package(url: "https://github.com/JohnSundell/ShellOut.git", from: "1.2.0"),
         .package(url: "https://github.com/onevcat/Rainbow.git", from: "2.1.0"),
         .package(url: "https://github.com/nsomar/Guaka.git", from: "0.1.3"),
+        .package(url: "https://github.com/apple/swift-package-manager.git", from: "0.1.0"),
         ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -37,6 +38,7 @@ let package = Package(
                 "ShellOut",
                 "Rainbow",
                 "PathKit",
+                "Utility"
                 ]),
         .testTarget(
             name: "MintTests",


### PR DESCRIPTION
Fixes #29

This uses SwiftPM itself to parse versions and sort them. 
Having this dependency paves the way for implementing #17, as well as possibly moving fetching to SwiftPM