### PR TITLE
Stream output

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -63,6 +63,15 @@
           "revision": "90abb3c4c9415afee34291e66e655c58a1902784",
           "version": "0.1.0"
         }
+      },
+      {
+        "package": "SwiftShell",
+        "repositoryURL": "https://github.com/kareman/SwiftShell.git",
+        "state": {
+          "branch": null,
+          "revision": "ecf0544d740c8d729275ac3d52543511153909d6",
+          "version": "4.0.0"
+        }
       }
     ]
   },

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/kylef/PathKit.git", from: "0.8.0"),
-        .package(url: "https://github.com/JohnSundell/ShellOut.git", from: "1.2.0"),
+        .package(url: "https://github.com/kareman/SwiftShell.git", from: "4.0.0"),
         .package(url: "https://github.com/onevcat/Rainbow.git", from: "2.1.0"),
         .package(url: "https://github.com/nsomar/Guaka.git", from: "0.1.3"),
         .package(url: "https://github.com/apple/swift-package-manager.git", from: "0.1.0"),
@@ -31,11 +31,12 @@ let package = Package(
                 "MintKit",
                 "Rainbow",
                 "Guaka",
+                "SwiftShell",
                 ]),
         .target(
             name: "MintKit",
             dependencies: [
-                "ShellOut",
+                "SwiftShell",
                 "Rainbow",
                 "PathKit",
                 "Utility"

--- a/Sources/MintKit/MintKit.swift
+++ b/Sources/MintKit/MintKit.swift
@@ -91,6 +91,9 @@ public struct Mint {
         print("🌱  Running \(package.commandVersion)...")
 
         var context = CustomContext(main)
+        context.env["MINT"] = "YES"
+        context.env["RESOURCE_PATH"] = ""
+        
         try context.runAndPrint(package.commandPath.string, arguments)
     }
 

--- a/Sources/MintKit/MintKit.swift
+++ b/Sources/MintKit/MintKit.swift
@@ -108,6 +108,7 @@ public struct Mint {
 
         if package.version.isEmpty {
             // we don't have a specific version, let's get the latest tag
+            print("🌱  Finding latest version of \(package.name)")
             let tagOutput = main.run(bash: "git ls-remote --tags --refs \(package.git)")
 
             if let error = tagOutput.error {

--- a/Sources/MintKit/MintKit.swift
+++ b/Sources/MintKit/MintKit.swift
@@ -1,4 +1,4 @@
-import ShellOut
+import SwiftShell
 import PathKit
 import Foundation
 import Rainbow
@@ -68,7 +68,7 @@ public struct Mint {
         print("Installed mint packages:\n\(packages.sorted().joined(separator: "\n"))")
     }
 
-    public static func run(repo: String, version: String, command: String) throws {
+    public static func run(repo: String, version: String, command: String, verbose: Bool) throws {
         let commandComponents = command.components(separatedBy: " ")
         let name = commandComponents.first!
         let arguments = commandComponents.count > 1 ? Array(commandComponents.suffix(from: 1)) : []
@@ -83,24 +83,24 @@ public struct Mint {
             }
         }
         let package = Package(repo: git, version: version, name: name)
-        try run(package, arguments: arguments)
+        try run(package, arguments: arguments, verbose: verbose)
     }
 
-    public static func run(_ package: Package, arguments: [String]) throws {
-        try install(package, force: false)
+    public static func run(_ package: Package, arguments: [String], verbose: Bool) throws {
+        try install(package, force: false, verbose: verbose)
         print("🌱  Running \(package.commandVersion)...")
 
-        let output = try shellOut(to: package.commandPath.string, arguments: arguments)
-        print(output)
+        var context = CustomContext(main)
+        try context.runAndPrint(package.commandPath.string, arguments)
     }
 
-    public static func install(repo: String, version: String, command: String, force: Bool) throws {
+    public static func install(repo: String, version: String, command: String, force: Bool, verbose: Bool) throws {
         let name = command.components(separatedBy: " ").first!
         let package = Package(repo: repo, version: version, name: name)
-        try install(package, force: force)
+        try install(package, force: force, verbose: verbose)
     }
 
-    public static func install(_ package: Package, force: Bool = false) throws {
+    public static func install(_ package: Package, force: Bool = false, verbose: Bool) throws {
 
         if !package.repo.contains("/") {
             throw MintError.invalidRepo(package.repo)
@@ -108,7 +108,12 @@ public struct Mint {
 
         if package.version.isEmpty {
             // we don't have a specific version, let's get the latest tag
-            let tagReferences = try shellOut(to: "git ls-remote --tags --refs \(package.git)")
+            let tagOutput = main.run(bash: "git ls-remote --tags --refs \(package.git)")
+
+            if let error = tagOutput.error {
+                throw error
+            }
+            let tagReferences = tagOutput.stdout
             if tagReferences.isEmpty {
                 package.version = "master"
             } else {
@@ -137,7 +142,7 @@ public struct Mint {
         try? packageCheckoutPath.delete()
         print("🌱  Cloning \(package.git) \(package.version.quoted)...")
         do {
-            try shellOut(to: "git clone --depth 1 -b \(package.version) \(package.git) \(package.repoPath)", at: checkoutPath.string)
+            try runCommand("git clone --depth 1 -b \(package.version) \(package.git) \(package.repoPath)", at: checkoutPath, verbose: verbose)
         } catch {
             throw MintError.repoNotFound(package.git)
         }
@@ -145,8 +150,7 @@ public struct Mint {
         try? package.installPath.delete()
         try package.installPath.mkpath()
         print("🌱  Building \(package.name). This may take a few minutes...")
-        //        try shellOut(to: "swift package clean", at: package.checkoutPath.string)
-        try shellOut(to: "swift build -c release", at: packageCheckoutPath.string)
+        try runCommand("swift build -c release", at: packageCheckoutPath, verbose: verbose)
 
         print("🌱  Installing \(package.name)...")
         let toolFile = packageCheckoutPath + ".build/release/\(package.name)"
@@ -186,6 +190,19 @@ public struct Mint {
                 return "https://\(string).git"
             } else {
                 return "https://github.com/\(string).git"
+            }
+        }
+    }
+
+    private static func runCommand(_ command: String, at: Path, verbose: Bool) throws {
+        var context = CustomContext(main)
+        context.currentdirectory = at.string
+        if verbose {
+            try context.runAndPrint(bash: command)
+        } else {
+            let output = context.run(bash: command)
+            if let error = output.error {
+                throw error
             }
         }
     }


### PR DESCRIPTION
This replaces ShellOut with SwiftShell. This allows for streaming of stdout and stderror, and easily allows custom contexts, which allows the following features.

- Resolves #35: stream output of run command
- Resolves #3: `--verbose` flag now shows output of cloning and building
- Resolves #5: `MINT=YES` and `RESOURCE_PATH=""` are now passed to the run command. This allows a tool to know if it is being run through mint, and allows us to change the resource path dynamically in the future.

