### PR TITLE
Global install and uninstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master
 
+- added `--global` flag to install executables globally #41
 - added streaming of run command output #36
 - added `--verbose` flag for cloning and building output #36
 - add `MINT` and `RESOURCE_PATH` envs #36

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Simply pass `--global` to `mint install` or `mint update` and that version will 
 
 Note that a mint install path will be added to your `$PATH`, and that only one global version can be installed at a time. If you need to run a specific older version use `mint run`.
 
+Note also, that after you install a global version you must launch a new shell to get access the package.
+
 ## Support
 If your Swift command line tool builds with the Swift Package Manager than it will automatically install and run with mint! You can add this to your `Installing` section in the readme:
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@ $ cd Mint
 $ make
 ```
 
+### Using Mint itself!
+
+##### Install
+```sh
+$ git clone https://github.com/yonaskolb/Mint.git
+$ cd Mint
+$ swift run mint install yonaskolb/mint --global
+```
+
+##### Update
+```sh
+$ mint install yonaskolb/mint --global
+```
+
 ### Swift Package Manager
 
 **Use CLI**
@@ -69,27 +83,15 @@ And then import wherever needed: `import MintKit`
 
 ## Usage
 
-Run `mint` to see usage instructions.
+Run `mint --help` to see usage instructions.
 
-```
-$ mint
-Usage:
-  mint [command]
+- **install**: Installs a package. If it is already installed this won't do anything
+- **run**: Runs a package. This will install it first if it isn't already installed.
+- **update**: Installs a package while enforcing an update and rebuild. Shouldn't be required unless you are pointing at a branch and want to update it.
+- **list**: Lists all currently installed packages and versions.
+- **uninstall**: Uninstalls a package by name.
 
-Available Commands:
-  install  Install a package
-  run      Run a package
-  update   Update a package
-  list     List all installed packages
-
-Use "mint [command] --help" for more information about a command.
-```
-
-- **Install**: Installs a package. If it is already installed this won't do anything
-- **Run**: Runs a package. This will install if first if it doesn't exist
-- **Update**: Installs a package while enforcing an update and rebuild. Shouldn't be required unless you are pointing at a branch and want to update.
-
-These commands all have 1 or 2 arguments:
+Run, install and update commands have 1 or 2 arguments:
 
 - **repo (required)**: This can be a shorthand for a github repo `install realm/SwiftLint` or a fully qualified git path `install https://github.com/realm/SwiftLint.git`. In the case of `run` you can also just pass the name of the repo if it is already installed `run swiftlint`. This will do a lookup of all installed packages. An optional version can be specified by appending `@version`, otherwise the newest tag or master will be used. Note that if you don't specify a version, the current tags must be loaded remotely each time.
 - **command (optional)**: The command to install or run. This defaults to the the last path in the repo (so for `realm/swiftlint` it will be `swiftlint`). In the case of `run` you can also pass any arguments to the command but make sure the whole thing is surrounded by quotes eg `mint run realm/swiftlint "swiftlint --path source"`
@@ -103,6 +105,13 @@ $ mint install yonaskolb/XcodeGen # use newest tag
 $ mint run yonaskolb/XcodeGen@1.2.4 # run 1.2.4
 $ mint run XcodeGen # use newest tag and find XcodeGen in installed tools
 ```
+
+### Global installs
+Mint can also be used to install a package so it is accessible from anywhere. This means you don't have to prepend commands with `mint run`. 
+
+Simply pass `--global` to `mint install` or `mint update` and that version will globally installed. 
+
+Note that a mint install path will be added to your `$PATH`, and that only one global version can be installed at a time. If you need to run a specific older version use `mint run`.
 
 ## Support
 If your Swift command line tool builds with the Swift Package Manager than it will automatically install and run with mint! You can add this to your `Installing` section in the readme:

--- a/Sources/Mint/main.swift
+++ b/Sources/Mint/main.swift
@@ -43,7 +43,7 @@ enum CommandError: Error, CustomStringConvertible {
     }
 }
 
-func getOptions(flags: Flags, args: [String]) throws -> (repo: String, version: String, command: String, verbose: Bool) {
+func getOptions(flags: Flags, args: [String]) throws -> (repo: String, version: String, command: String, verbose: Bool, global: Bool) {
     guard let repoVersion = args.first else { throw CommandError.repoRequired }
     let version: String
     let command: String
@@ -69,11 +69,16 @@ func getOptions(flags: Flags, args: [String]) throws -> (repo: String, version: 
     default:
         throw CommandError.tooManyArguments
     }
-    return (repo: repo, version: version, command: command, verbose: flags.getBool(name: "verbose") ?? false)
+    return (repo: repo,
+            version: version,
+            command: command,
+            verbose: flags.getBool(name: "verbose") ?? false,
+            global: flags.getBool(name: "global") ?? false)
 }
 
 let versionFlag = Flag(longName: "version", value: false, description: "Prints the version")
 let verboseFlag = Flag(longName: "verbose", value: false, description: "Show installation output")
+let globalFlag = Flag(longName: "global", value: false, description: "Install executable globally so it's accessible without \"mint run\". This will overwrite any other globally installed versions. An extra $PATH entry will also be added")
 
 let command = Command(usage: "mint", flags: [versionFlag])
 command.run = { flags, _ in
@@ -92,24 +97,31 @@ This command takes allows you to specify a repo, a version and an executable com
 - The second argument qualifies the command name, otherwise this will be assumed to the be the end of the repo name.
 """
 
-let runCommand = Command(usage: "run repo (version) (command)", shortMessage: "Run a package", longMessage: "This will run a package tool. If it isn't installed if will do so first.\n\(commandHelp) The command can include any arguments and flags but the whole command must then be surrounded in quotes.", flags: [verboseFlag], example: "mint run realm/SwiftLint@0.22.0") { flags, args in
+let runCommand = Command(usage: "run package(@version) (command)", shortMessage: "Run a package", longMessage: "This will run a package. If it isn't installed if will do so first.\n\(commandHelp) The command can include any arguments and flags but the whole command must then be surrounded in quotes.", flags: [verboseFlag], example: "mint run realm/SwiftLint@0.22.0") { flags, args in
     catchError {
         let options = try getOptions(flags: flags, args: args)
         try mint.run(repo: options.repo, version: options.version, command: options.command, verbose: options.verbose)
     }
 }
 
-let installCommand = Command(usage: "install repo (version) (command)", shortMessage: "Install a package", longMessage: "This will install a package. If it's already installed no action will be taken.\n\(commandHelp)", flags: [verboseFlag], example: "mint install realm/SwiftLint@0.22.0") { flags, args in
+let installCommand = Command(usage: "install package(@version) (command)", shortMessage: "Install a package", longMessage: "This will install a package. If it's already installed no action will be taken.\n\(commandHelp)", flags: [verboseFlag, globalFlag], example: "mint install realm/SwiftLint@0.22.0") { flags, args in
     catchError {
         let options = try getOptions(flags: flags, args: args)
-        try mint.install(repo: options.repo, version: options.version, command: options.command, force: false, verbose: options.verbose)
+        try mint.install(repo: options.repo, version: options.version, command: options.command, force: false, verbose: options.verbose, global: options.global)
     }
 }
 
-let updateCommand = Command(usage: "update repo (version) (command)", shortMessage: "Update a package", longMessage: "This will update a package even if it's already installed.\n\(commandHelp)", flags: [verboseFlag], example: "mint install realm/SwiftLint@0.22.0") { flags, args in
+let updateCommand = Command(usage: "update package(@version) (command)", shortMessage: "Update a package", longMessage: "This will update a package even if it's already installed.\n\(commandHelp)", flags: [verboseFlag, globalFlag], example: "mint install realm/SwiftLint@0.22.0") { flags, args in
     catchError {
         let options = try getOptions(flags: flags, args: args)
-        try mint.install(repo: options.repo, version: options.version, command: options.command, force: true, verbose: options.verbose)
+        try mint.install(repo: options.repo, version: options.version, command: options.command, force: true, verbose: options.verbose, global: options.global)
+    }
+}
+
+let uninstallCommand = Command(usage: "uninstall (package)", shortMessage: "Uninstall a package", longMessage: "This will uninstall a package by name. See all installed packages with \"mint list\")", example: "mint uninstall SwiftLint") { flags, args in
+    catchError {
+        let options = try getOptions(flags: flags, args: args)
+        try mint.uninstall(name: options.repo)
     }
 }
 
@@ -125,6 +137,7 @@ let bootstrapCommand = Command(usage: "bootstrap") { _, _ in
 command.add(subCommand: runCommand)
 command.add(subCommand: installCommand)
 command.add(subCommand: updateCommand)
+command.add(subCommand: uninstallCommand)
 command.add(subCommand: listCommand)
 
 command.execute()

--- a/Sources/MintKit/Mint.swift
+++ b/Sources/MintKit/Mint.swift
@@ -223,6 +223,7 @@ public struct Mint {
         let exportCommand = "export PATH=\"\(installsPath):$PATH\""
 
         // add $PATH to current shell
+        // FIXME: this doesn't seem to work
         main.run(bash: exportCommand)
 
         // add $PATH to common files

--- a/Sources/MintKit/Mint.swift
+++ b/Sources/MintKit/Mint.swift
@@ -55,24 +55,26 @@ public struct Mint {
     }
 
     @discardableResult
-    public func listPackages() throws -> [String] {
+    public func listPackages() throws -> [String: [String]] {
         guard packagesPath.exists else {
             print("No mint packages installed")
-            return []
+            return [:]
         }
 
+        var versionsByPackage: [String: [String]] = [:]
         let packages: [String] = try packagesPath.children().filter { $0.isDirectory }.map { packagePath in
-            let versions = try (packagePath + "build").children().sorted()
-            let packageName = packagePath.lastComponent.split(separator: "_").last!
+            let versions = try (packagePath + "build").children().sorted().map { $0.lastComponent }
+            let packageName = String(packagePath.lastComponent.split(separator: "_").last!)
             var package = "  \(packageName)"
             for version in versions {
-                package += "\n    - \(version.lastComponent)"
+                package += "\n    - \(version)"
+                versionsByPackage[packageName, default: []].append(version)
             }
             return package
         }
 
         print("Installed mint packages:\n\(packages.sorted().joined(separator: "\n"))")
-        return packages
+        return versionsByPackage
     }
 
     @discardableResult
@@ -107,7 +109,7 @@ public struct Mint {
     }
 
     @discardableResult
-    public func install(repo: String, version: String, command: String, force: Bool, verbose: Bool = false, global: Bool = false) throws -> Package {
+    public func install(repo: String, version: String, command: String, force: Bool = false, verbose: Bool = false, global: Bool = false) throws -> Package {
         let name = command.components(separatedBy: " ").first!
         let package = Package(repo: repo, version: version, name: name)
         try install(package, force: force, verbose: verbose, global: global)

--- a/Sources/MintKit/Mint.swift
+++ b/Sources/MintKit/Mint.swift
@@ -242,6 +242,7 @@ public struct Mint {
                 if !existingString.contains(exportSection) {
                     let newString = "\(existingString)\n\n\(exportSection)"
                     try file.write(newString)
+                    print("🌱  Added mint install $PATH to \(file.string)")
                 }
             }
         }

--- a/Tests/MintTests/MintTests.swift
+++ b/Tests/MintTests/MintTests.swift
@@ -57,24 +57,28 @@ class MintTests: XCTestCase {
 
     func testInstallCommand() throws {
 
+        let globalPath = mint.installsPath + "mint"
+
         // install specific version
         let specificPackage = try mint.install(repo: testRepo, version: testVersion, command: testCommand)
         expectMintVersion(package: specificPackage)
 
         // check that not globally installed
-        XCTAssertFalse((mint.installsPath + "mint").exists)
+        XCTAssertFalse(globalPath.exists)
 
-        // install already installed version
-        try mint.install(repo: testRepo, version: testVersion, command: testCommand)
-
-        // install global version
+        // install already installed version globally
         try mint.install(repo: testRepo, version: testVersion, command: testCommand, global: true)
-        XCTAssertTrue((mint.installsPath + "mint").exists)
+
+        XCTAssertTrue(globalPath.exists)
+        let globalOutput = main.run(globalPath.string, "--version")
+        XCTAssertEqual(globalOutput.stdout, testVersion)
 
         // install latest version
-        let latestPackage = try mint.install(repo: testRepo, version: "", command: testCommand)
+        let latestPackage = try mint.install(repo: testRepo, version: "", command: testCommand, global: true)
         expectMintVersion(package: latestPackage)
         XCTAssertEqual(latestPackage.version, Mint.version)
+        let latestGlobalOutput = main.run(globalPath.string, "--version")
+        XCTAssertEqual(latestGlobalOutput.stdout, Mint.version)
 
         // check package list has installed versions
         let installedPackages = try mint.listPackages()
@@ -85,7 +89,7 @@ class MintTests: XCTestCase {
         try mint.uninstall(name: "mint")
 
         // check not globally installed
-        XCTAssertFalse((mint.installsPath + "mint").exists)
+        XCTAssertFalse(globalPath.exists)
 
         // check package list is empty
         XCTAssertTrue(try mint.listPackages().isEmpty)

--- a/Tests/MintTests/MintTests.swift
+++ b/Tests/MintTests/MintTests.swift
@@ -11,9 +11,9 @@ class MintTests: XCTestCase {
     let testVersion = "0.6.0"
     let testCommand = "mint"
 
-    override class func setUp() {
+    override func setUp() {
         super.setUp()
-        try? (Path.temporary + "mint").delete()
+        try? mint.path.delete()
     }
 
     func testPackagePaths() {
@@ -48,34 +48,77 @@ class MintTests: XCTestCase {
         }
     }
 
+    func expectMintVersion(package: Package) {
+        let packagePath = PackagePath(path: mint.packagesPath, package: package)
+        XCTAssertTrue(packagePath.commandPath.exists)
+        let output = main.run(packagePath.commandPath.string, "--version")
+        XCTAssertEqual(output.stdout, package.version)
+    }
+
     func testInstallCommand() throws {
 
         // install specific version
-        let testPackage = try mint.install(repo: testRepo, version: testVersion, command: testCommand, force: false)
-        let testPackagePath = PackagePath(path: mint.packagesPath, package: testPackage)
-        XCTAssertTrue(testPackagePath.commandPath.exists)
-        let output = main.run(testPackagePath.commandPath.string, "--version")
-        XCTAssertEqual(output.stdout, testVersion)
+        let specificPackage = try mint.install(repo: testRepo, version: testVersion, command: testCommand)
+        expectMintVersion(package: specificPackage)
+
+        // check that not globally installed
+        XCTAssertFalse((mint.installsPath + "mint").exists)
 
         // install already installed version
-        try mint.install(repo: testRepo, version: testVersion, command: testCommand, force: false)
+        try mint.install(repo: testRepo, version: testVersion, command: testCommand)
+
+        // install global version
+        try mint.install(repo: testRepo, version: testVersion, command: testCommand, global: true)
+        XCTAssertTrue((mint.installsPath + "mint").exists)
 
         // install latest version
-        let latestPackage = try mint.install(repo: testRepo, version: "", command: testCommand, force: false)
+        let latestPackage = try mint.install(repo: testRepo, version: "", command: testCommand)
+        expectMintVersion(package: latestPackage)
         XCTAssertEqual(latestPackage.version, Mint.version)
 
-        let packages = try mint.listPackages()
-        XCTAssertTrue(packages.count > 0)
+        // check package list has installed versions
+        let installedPackages = try mint.listPackages()
+        XCTAssertEqual(installedPackages["mint", default: []], [testVersion, latestPackage.version])
+        XCTAssertEqual(installedPackages.count, 1)
+
+        // uninstall
+        try mint.uninstall(name: "mint")
+
+        // check not globally installed
+        XCTAssertFalse((mint.installsPath + "mint").exists)
+
+        // check package list is empty
+        XCTAssertTrue(try mint.listPackages().isEmpty)
     }
 
     func testRunCommand() throws {
-        // run existing version
-        try mint.run(repo: testRepo, version: testVersion, command: "mint --version")
 
-        // install and run specific version
-        let package = try mint.run(repo: testRepo, version: testVersion, command: "mint --version")
-        let packagePath = PackagePath(path: mint.packagesPath, package: package)
-        XCTAssertTrue(packagePath.commandPath.exists)
+        let versionCommand = "mint --version"
+        // run a specific version
+        let specificPackage = try mint.run(repo: testRepo, version: testVersion, command: versionCommand)
+        expectMintVersion(package: specificPackage)
+
+        // run an already installed version
+        try mint.run(repo: testRepo, version: testVersion, command: versionCommand)
+
+        // run without arguments
+        try mint.run(repo: testRepo, version: testVersion, command: "mint")
+
+        // run latest version
+        let latestPackage = try mint.run(repo: testRepo, version: "", command: versionCommand)
+        expectMintVersion(package: latestPackage)
+        XCTAssertEqual(latestPackage.version, Mint.version)
+
+        // check package list has installed versions
+        let installedPackages = try mint.listPackages()
+        XCTAssertEqual(installedPackages["mint", default: []], [testVersion, latestPackage.version])
+        XCTAssertEqual(installedPackages.count, 1)
+
+        // uninstall
+        try mint.uninstall(name: "mint")
+
+        // check package list is empty
+        XCTAssertTrue(try mint.listPackages().isEmpty)
     }
 
     func testMintErrors() {


### PR DESCRIPTION
Resolves #1 

This allows installing a package globally. At the moment this is behind a `--global` flag, which may change to the default in the future.
There is also an obligatory `uninstall` command