### PR TITLE
Change global install path from custom to /usr/local/bin

### DIFF
--- a/Sources/Mint/main.swift
+++ b/Sources/Mint/main.swift
@@ -4,7 +4,7 @@ import Rainbow
 import SwiftShell
 
 do {
-    let mint = Mint(path: "/usr/local/lib/mint")
+    let mint = Mint()
     let mintInterface = MintInterace(mint: mint)
     try mintInterface.execute(arguments: Array(ProcessInfo.processInfo.arguments.dropFirst()))
 } catch {

--- a/Sources/MintKit/Commands/Question.swift
+++ b/Sources/MintKit/Commands/Question.swift
@@ -1,0 +1,35 @@
+//
+//  Question.swift
+//  MintKit
+//
+//  Created by Yonas Kolb on 5/1/18.
+//
+
+import Foundation
+
+struct Question {
+
+    let printer: (String) -> ()
+    init(printer: @escaping (String)-> () = {print($0)}) {
+        self.printer = printer
+    }
+
+    func ask(_ question: String, answers: [String]) -> String {
+        printer(question)
+
+        func ask()-> String {
+            guard let answer = readLine() else { return "" }
+            let lowercasedAnswers = answers.map { $0.lowercased() }
+            if !lowercasedAnswers.contains(answer.lowercased()) {
+                print("You must respond with one of the following:\n\(answers.joined(separator: "\n"))")
+                return ask()
+            }
+            return answer
+        }
+        return ask()
+    }
+
+    func confirmation(_ question: String) -> Bool {
+        return ask("\(question) (y/n)", answers: ["y","n"]) == "y"
+    }
+}

--- a/Tests/MintTests/MintTests.swift
+++ b/Tests/MintTests/MintTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 class MintTests: XCTestCase {
 
-    let mint = Mint(path: Path.temporary + "mint")
+    let mint = Mint(path: Path.temporary + "mint", installationPath: Path.temporary + "mint-installs")
     let testRepo = "yonaskolb/simplepackage"
     let testVersion = "2.0.0"
     let latestVersion = "3.0.0"
@@ -14,20 +14,23 @@ class MintTests: XCTestCase {
     override func setUp() {
         super.setUp()
         try? mint.path.delete()
+        try? mint.installationPath.delete()
     }
 
     func testPackagePaths() {
 
-        let mint = Mint(path: "testPath/mint")
+        let testMint = Mint(path: "/testPath/mint", installationPath: "/testPath/mint-installs")
         let package = Package(repo: "yonaskolb/mint", version: "1.2.0", name: "mint")
-        let packagePath = PackagePath(path: mint.packagesPath, package: package)
+        let packagePath = PackagePath(path: testMint.packagesPath, package: package)
 
-        XCTAssertEqual(mint.packagesPath, "testPath/mint/packages")
+        XCTAssertEqual(testMint.path, "/testPath/mint")
+        XCTAssertEqual(testMint.packagesPath, "/testPath/mint/packages")
+        XCTAssertEqual(testMint.installationPath, "/testPath/mint-installs")
         XCTAssertEqual(packagePath.gitPath, "https://github.com/yonaskolb/mint.git")
         XCTAssertEqual(packagePath.repoPath, "github.com_yonaskolb_mint")
-        XCTAssertEqual(packagePath.packagePath, "testPath/mint/packages/github.com_yonaskolb_mint")
-        XCTAssertEqual(packagePath.installPath, "testPath/mint/packages/github.com_yonaskolb_mint/build/1.2.0")
-        XCTAssertEqual(packagePath.commandPath, "testPath/mint/packages/github.com_yonaskolb_mint/build/1.2.0/mint")
+        XCTAssertEqual(packagePath.packagePath, "/testPath/mint/packages/github.com_yonaskolb_mint")
+        XCTAssertEqual(packagePath.installPath, "/testPath/mint/packages/github.com_yonaskolb_mint/build/1.2.0")
+        XCTAssertEqual(packagePath.commandPath, "/testPath/mint/packages/github.com_yonaskolb_mint/build/1.2.0/mint")
     }
 
     func testPackageGitPaths() {
@@ -57,7 +60,7 @@ class MintTests: XCTestCase {
 
     func testInstallCommand() throws {
 
-        let globalPath = mint.installsPath + testCommand
+        let globalPath = mint.installationPath + testCommand
 
         // install specific version
         let specificPackage = try mint.install(repo: testRepo, version: testVersion, command: testCommand)


### PR DESCRIPTION
This is an alternative to #41.

It changes the global installation path from a custom one that need a new `$PATH` entry, to the standard `/usr/local/bin`. The installed file is still symlinked to Mint's own directory.

This greatly simplifies things and keeps Mint out of peoples bash configs.

Mint asks for confirmation before trying to overwrite or remove an existing executable that is not symlinked to mint.

With this method, I'd be more comfortable making Mint install globally by default
  