### PR TITLE
Improve mint output

### DIFF
--- a/Sources/MintKit/Commands/InstallCommand.swift
+++ b/Sources/MintKit/Commands/InstallCommand.swift
@@ -8,7 +8,7 @@ class InstallCommand: InstallOrUpdateCommand {
             mint: mint,
             parser: parser,
             name: "install",
-            description: "Installs a package. If the version is already installed no action will be taken",
+            description: "Install a package. If the version is already installed no action will be taken",
             update: false
         )
     }
@@ -21,7 +21,7 @@ class UpdateCommand: InstallOrUpdateCommand {
             mint: mint,
             parser: parser,
             name: "update",
-            description: "Updates a package even if it's already installed",
+            description: "Update a package even if it's already installed",
             update: true
         )
     }

--- a/Sources/MintKit/Commands/ListCommand.swift
+++ b/Sources/MintKit/Commands/ListCommand.swift
@@ -4,7 +4,7 @@ import Utility
 class ListCommand: MintCommand {
 
     init(mint: Mint, parser: ArgumentParser) {
-        super.init(mint: mint, parser: parser, name: "list", description: "Lists all the currently installed packages")
+        super.init(mint: mint, parser: parser, name: "list", description: "List all the currently installed packages")
     }
 
     override func execute(parsedArguments: ArgumentParser.Result) throws {

--- a/Sources/MintKit/Commands/MintInterface.swift
+++ b/Sources/MintKit/Commands/MintInterface.swift
@@ -12,7 +12,7 @@ public class MintInterace {
 
     public func execute(arguments: [String]) throws {
         let parser = ArgumentParser(commandName: "mint", usage: "[subcommand]", overview: "Run and install Swift Package Manager executables")
-        let versionArgument = parser.add(option: "--version", shortName: "-v", kind: Bool.self, usage: "Prints the current version of Mint")
+        let versionArgument = parser.add(option: "--version", shortName: "-v", kind: Bool.self, usage: "Print the current version of Mint")
 
         let commands: [String: MintCommand] = [
             "run": RunCommand(mint: mint, parser: parser),

--- a/Sources/MintKit/Commands/MintInterface.swift
+++ b/Sources/MintKit/Commands/MintInterface.swift
@@ -11,7 +11,7 @@ public class MintInterace {
     }
 
     public func execute(arguments: [String]) throws {
-        let parser = ArgumentParser(commandName: "mint", usage: "mint [subcommand]", overview: "run and install Swift PM executables")
+        let parser = ArgumentParser(commandName: "mint", usage: "[subcommand]", overview: "Run and install Swift Package Manager executables")
         let versionArgument = parser.add(option: "--version", shortName: "-v", kind: Bool.self, usage: "Prints the current version of Mint")
 
         let commands: [String: MintCommand] = [

--- a/Sources/MintKit/Commands/RunCommand.swift
+++ b/Sources/MintKit/Commands/RunCommand.swift
@@ -6,7 +6,7 @@ class RunCommand: PackageCommand {
     var commandArgument: PositionalArgument<[String]>!
 
     init(mint: Mint, parser: ArgumentParser) {
-        super.init(mint: mint, parser: parser, name: "run", description: "Installs and then runs a package")
+        super.init(mint: mint, parser: parser, name: "run", description: "Install and then run a package")
         commandArgument = subparser.add(positional: "command", kind: [String].self, optional: true, strategy: .remaining, usage: "The command to run. This will default to the package name")
     }
 

--- a/Sources/MintKit/Commands/UninstallCommand.swift
+++ b/Sources/MintKit/Commands/UninstallCommand.swift
@@ -6,7 +6,7 @@ class UninstallCommand: MintCommand {
     var packageArgument: PositionalArgument<String>!
 
     init(mint: Mint, parser: ArgumentParser) {
-        super.init(mint: mint, parser: parser, name: "uninstall", description: "Uninstalls a package by name")
+        super.init(mint: mint, parser: parser, name: "uninstall", description: "Uninstall a package by name")
         packageArgument = subparser.add(positional: "name", kind: String.self, optional: false, usage: "The name of the package to uninstall")
     }
 

--- a/Sources/MintKit/Commands/UninstallCommand.swift
+++ b/Sources/MintKit/Commands/UninstallCommand.swift
@@ -6,7 +6,7 @@ class UninstallCommand: MintCommand {
     var packageArgument: PositionalArgument<String>!
 
     init(mint: Mint, parser: ArgumentParser) {
-        super.init(mint: mint, parser: parser, name: "uninstall", description: "Uninstalls a package by name.\nUse mint list to see all installed packages")
+        super.init(mint: mint, parser: parser, name: "uninstall", description: "Uninstalls a package by name")
         packageArgument = subparser.add(positional: "name", kind: String.self, optional: false, usage: "The name of the package to uninstall")
     }
 


### PR DESCRIPTION
Just improved the output like this. I followed the way `swift package` command does as you can see.

---

Before
```sh
OVERVIEW: run and install Swift PM executables

USAGE: mint mint [subcommand]

OPTIONS:
  --version, -v
              Prints the current version of Mint
  --help      Display available options

SUBCOMMANDS:
  install     Installs a package. If the version is already installed no action will be taken
  list        Lists all the currently installed packages
  run         Installs and then runs a package
  uninstall   Uninstalls a package by name.
Use mint list to see all installed packages
  update      Updates a package even if it's already installed
```

After
```sh
OVERVIEW: Run and install Swift Package Manager executables

USAGE: mint [subcommand]

OPTIONS:
  --version, -v
              Print the current version of Mint
  --help      Display available options

SUBCOMMANDS:
  install     Install a package. If the version is already installed no action will be taken
  list        List all the currently installed packages
  run         Install and then run a package
  uninstall   Uninstall a package by name
  update      Update a package even if it's already installed
```