### PR TITLE
Update the list command for display of global installed versions

### DIFF
--- a/Sources/MintKit/Commands/ListCommand.swift
+++ b/Sources/MintKit/Commands/ListCommand.swift
@@ -4,7 +4,13 @@ import Utility
 class ListCommand: MintCommand {
 
     init(mint: Mint, parser: ArgumentParser) {
-        super.init(mint: mint, parser: parser, name: "list", description: "List all the currently installed packages")
+
+        let description = """
+        List all the currently installed packages
+        Globally installed packages are marked with *
+        """
+        
+        super.init(mint: mint, parser: parser, name: "list", description: description)
     }
 
     override func execute(parsedArguments: ArgumentParser.Result) throws {

--- a/Sources/MintKit/Mint.swift
+++ b/Sources/MintKit/Mint.swift
@@ -55,22 +55,16 @@ public struct Mint {
     func getGlobalInstalledPackages() -> [String: String] {
         guard installationPath.exists,
             let packages = try? installationPath.children() else {
-                print("No mint packages installed to global")
                 return [:]
         }
 
         return packages.reduce(into: [:]) { result, package in
             guard let installStatus = try? InstallStatus(path: package, mintPackagesPath: path),
-                case .mint = installStatus.status,
+                case let .mint(version) = installStatus.status,
                 let symlink = try? package.symlinkDestination() else {
                     return
             }
-
-            var componets = symlink.components
-            componets.removeLast()
-            let version = componets.removeLast()
-            componets.removeLast()
-            let packageName = String(componets.removeLast().split(separator: "_").last!)
+            let packageName = String(symlink.parent().parent().parent().lastComponent.split(separator: "_").last!)
             result[packageName] = version
         }
     }

--- a/Tests/MintTests/MintTests.swift
+++ b/Tests/MintTests/MintTests.swift
@@ -96,6 +96,7 @@ class MintTests: XCTestCase {
 
         // check not globally installed
         XCTAssertFalse(globalPath.exists)
+        XCTAssertEqual(mint.getGlobalInstalledPackages(), [:])
 
         // check package list is empty
         XCTAssertTrue(try mint.listPackages().isEmpty)

--- a/Tests/MintTests/MintTests.swift
+++ b/Tests/MintTests/MintTests.swift
@@ -68,6 +68,7 @@ class MintTests: XCTestCase {
 
         // check that not globally installed
         XCTAssertFalse(globalPath.exists)
+        XCTAssertEqual(mint.getGlobalInstalledPackages(), [:])
 
         // install already installed version globally
         try mint.install(repo: testRepo, version: testVersion, command: testCommand, global: true)
@@ -75,6 +76,7 @@ class MintTests: XCTestCase {
         XCTAssertTrue(globalPath.exists)
         let globalOutput = main.run(globalPath.string)
         XCTAssertEqual(globalOutput.stdout, testVersion)
+        XCTAssertEqual(mint.getGlobalInstalledPackages(), [testCommand: testVersion])
 
         // install latest version
         let latestPackage = try mint.install(repo: testRepo, version: "", command: testCommand, global: true)
@@ -82,6 +84,7 @@ class MintTests: XCTestCase {
         XCTAssertEqual(latestPackage.version, latestVersion)
         let latestGlobalOutput = main.run(globalPath.string)
         XCTAssertEqual(latestGlobalOutput.stdout, latestVersion)
+        XCTAssertEqual(mint.getGlobalInstalledPackages(), [testCommand: latestVersion])
 
         // check package list has installed versions
         let installedPackages = try mint.listPackages()


### PR DESCRIPTION
I changed of the list command to display global version.
When multiple versions are installed in mint, a global installed version is represented by asterisk `*`

### Sample

```shell
$ mint list
Installed mint packages:
  simplepackage
    - 2.0.0
    - 3.0.0 *
```