### PR TITLE
Parse current OS version as swiftc target

### DIFF
--- a/Sources/MintKit/Mint.swift
+++ b/Sources/MintKit/Mint.swift
@@ -194,8 +194,12 @@ public struct Mint {
 
         try? packagePath.installPath.delete()
         try packagePath.installPath.mkpath()
+
+        let osVersion = ProcessInfo.processInfo.operatingSystemVersion
+        let target = "x86_64-apple-macosx\(osVersion.majorVersion).\(osVersion.minorVersion)"
+
         print("🌱  Building \(package.name). This may take a few minutes...")
-        try runCommand("swift build -c release", at: packageCheckoutPath, verbose: verbose)
+        try runCommand("swift build -c release -Xswiftc -target -Xswiftc \(target)", at: packageCheckoutPath, verbose: verbose)
 
         print("🌱  Installing \(package.name)...")
         let toolFile = packageCheckoutPath + ".build/release/\(package.name)"


### PR DESCRIPTION
Fixes #58 🚀 

I have also confirmed that this fixes building of Carthage 0.29.x:

<img width="618" alt="screen shot 2018-03-28 at 14 59 41" src="https://user-images.githubusercontent.com/189580/38033774-ae4e7f42-3298-11e8-8e7a-dfd5c48392da.png">
