### PR TITLE
Add which command for printing full path to binary

### DIFF
--- a/Sources/MintKit/Commands/MintInterface.swift
+++ b/Sources/MintKit/Commands/MintInterface.swift
@@ -20,6 +20,7 @@ public class MintInterface {
             "update": UpdateCommand(mint: mint, parser: parser),
             "uninstall": UninstallCommand(mint: mint, parser: parser),
             "list": ListCommand(mint: mint, parser: parser),
+            "which": WhichCommand(mint: mint, parser: parser),
         ]
 
         let parsedArguments = try parser.parse(arguments)

--- a/Sources/MintKit/Commands/WhichCommand.swift
+++ b/Sources/MintKit/Commands/WhichCommand.swift
@@ -1,0 +1,19 @@
+import Foundation
+import Utility
+
+class WhichCommand: PackageCommand {
+
+    var commandArgument: PositionalArgument<String>!
+
+    init(mint: Mint, parser: ArgumentParser) {
+        super.init(mint: mint, parser: parser, name: "which", description: "Print the full path to installed binary")
+        commandArgument = subparser.add(positional: "command", kind: String.self, optional: true, usage: "The command to run. This will default to the package name")
+    }
+
+    override func execute(parsedArguments: ArgumentParser.Result, repo: String, version: String, verbose: Bool) throws {
+        let command = parsedArguments.get(commandArgument)
+        let path = try mint.which(repo: repo, version: version, command: command)
+
+        print(path)
+    }
+}


### PR DESCRIPTION
Example usage:

```sh
$ mint which Carthage/Carthage@0.29.0 carthage
/usr/local/lib/mint/packages/github.com_Carthage_Carthage/build/0.29.0/carthage
```

```sh
$ mint which LinusU/RasterizeXCAssets 
/usr/local/lib/mint/packages/github.com_LinusU_RasterizeXCAssets/build/1.0.0-alpha.2/RasterizeXCAssets
```

```sh
$ mint which carthage                         
/usr/local/lib/mint/packages/github.com_Carthage_Carthage/build/0.29.0/carthage
```

```sh
$ mint which LinusU/NotFound        
🌱  Git repo not found at "https://github.com/LinusU/NotFound.git"
```