### PR TITLE
Fix the timing to adapt silent option

### DIFF
--- a/Sources/MintCLI/Commands/RunCommand.swift
+++ b/Sources/MintCLI/Commands/RunCommand.swift
@@ -13,6 +13,13 @@ class RunCommand: PackageCommand {
                    description: "Install and then run a package")
     }
 
+    override func execute() throws {
+        if silent.value {
+            mint.standardOut = PipeStream()
+        }
+        try super.execute()
+    }
+
     override func execute(repo: String, version: String) throws {
         var arguments = command.value
 
@@ -23,9 +30,6 @@ class RunCommand: PackageCommand {
             arguments = firstArg.split(separator: " ").map(String.init)
         }
 
-        if silent.value {
-            mint.standardOut = PipeStream()
-        }
         try mint.run(repo: repo, version: version, arguments: arguments)
     }
 }


### PR DESCRIPTION
Fix the problem that "🌱  Using \"\(package.repo)\" \"\(package.version)\" from Mintfile." is output even when the silent option is enabled.

Refs
- https://github.com/yonaskolb/Mint/pull/64
- https://github.com/yonaskolb/Mint/pull/72
- https://github.com/yonaskolb/Mint/pull/77