### PR TITLE
Update xcodegen version in Mintfile example

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ A `Mintfile` can specify a list of versioned packages. It makes installing and r
 Simply place this file in the directory you're running Mint in. The format of the `Mintfile` is simply a list of packages in the same form as the usual package parameter:
 
 ```
-yonaskolb/xcodegen@0.9.0
+yonaskolb/xcodegen@1.10.3
 yonaskolb/genesis@0.2.0
 ```
 


### PR DESCRIPTION
When running the Mintfile with version 0.9.0 like stated in the Readme mint exits with 
`fatal: Remote branch 0.9.0 not found in upstream origin
Couldn't clone https://github.com/yonaskolb/xcodegen.git 0.9.0`.

Since there is a newer version of xcodegen around I think it would be a good idea to correct that version.