### PR TITLE
Fix failing to copy nested resources

### DIFF
--- a/Sources/MintKit/Mint.swift
+++ b/Sources/MintKit/Mint.swift
@@ -261,7 +261,9 @@ public class Mint {
             for resource in resources {
                 let resourcePath = packageCheckoutPath + resource
                 if resourcePath.exists {
-                    try resourcePath.copy(packagePath.installPath + resource)
+                    let filename = String(resource.split(separator: "/").last!)
+                    let dest = packagePath.installPath + filename
+                    try SwiftCLI.run(bash: "cp -R \"\(resourcePath)\" \"\(dest)\"")
                 } else {
                     standardOut <<< "resource \(resource) doesn't exist".yellow
                 }


### PR DESCRIPTION
# before
```
$ mint install toshi0383/hackscode
🌱  Finding latest version of hackscode
🌱  Resolved latest version of hackscode to 0.2.2
🌱  Cloning https://github.com/toshi0383/hackscode.git 0.2.2...
🌱  Building hackscode with SPM...
🌱  Installing...
🌱  Copying resources for hackscode: Sources/Scripts/xquick.sh ...
An error occurred: Error Domain=NSCocoaErrorDomain Code=4 "The file “xquick.sh” doesn’t exist." UserInfo={NSSourceFilePathErrorKey=/var/folders/f1/drl_8qdj0qs19y07br7q313xr5q2d9/T/mint_554643071.423989/github.com_toshi0383_hackscode/Sources/Scripts/xquick.sh, NSUserStringVariant=(
    Copy
), NSDestinationFilePath=/usr/local/lib/mint/packages/github.com_toshi0383_hackscode/build/0.2.2/Sources/Scripts/xquick.sh, NSFilePath=/var/folders/f1/drl_8qdj0qs19y07br7q313xr5q2d9/T/mint_554643071.423989/github.com_toshi0383_hackscode/Sources/Scripts/xquick.sh, NSUnderlyingError=0x7f9f7bc0bd70 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
```

# After
```
$ mint install toshi0383/hackscode
🌱  Finding latest version of hackscode
🌱  Resolved latest version of hackscode to 0.2.2
🌱  Cloning https://github.com/toshi0383/hackscode.git 0.2.2...
🌱  Building hackscode with SPM...
🌱  Installing...
🌱  Copying resources for hackscode: Sources/Scripts/xquick.sh ...
```