### PR TITLE
Rename global to link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,16 @@ This would install and run [SwiftLint](https://github.com/realm/SwiftLint) versi
 Mint is designed to be used with Swift command line tools that build with the Swift Package Manager. It makes installing, running and distributing these tools much easier.
 
 - ✅ easily run a specific **version** of a package
-- ✅ install a package **globally**
+- ✅ **link** a package **globally**
 - ✅ builds are **cached** by version
 - ✅ use **different versions** of a package side by side
 - ✅ easily run the **latest** version of a package
 - ✅ distribute your own packages **without recipes and formulas**
 - ✅ specify a list of versioned packages in a **Mintfile** for easy use
 
-Homebrew is a popular method of distributing Swift executables, but that requires creating a formula and then maintaining that formula. Running specific versions of homebrew installations can also be tricky as only one global version is installed at any one time. Mint installs your package via SPM and lets you run multiple versions of that package, which are globally installed and cached on demand.
+Homebrew is a popular method of distributing Swift executables, but that requires creating a formula and then maintaining that formula. Running specific versions of homebrew installations can also be tricky as only one global version is installed at any one time. Mint installs your package via SPM and lets you run multiple versions of that package, which are installed and cached in a central place.
 
 If your Swift executable package builds with SPM, then it can be run with Mint! See [Support](#support) for details.
-
 
 ## Why is it called Mint?
 Swift Packager Manager Tools -> SPMT -> Spearmint -> Mint! 🌱😄
@@ -101,15 +100,15 @@ An optional version can be specified by appending `@version`, otherwise the newe
 #### Examples
 ```sh
 $ mint run yonaskolb/XcodeGen@1.2.4 xcodegen --spec spec.yml # pass some arguments
-$ mint install yonaskolb/XcodeGen@1.2.4 --prevent-global # installs a certain version but not globally
+$ mint install yonaskolb/XcodeGen@1.2.4 --no-link # installs a certain version but doesn't link it globally
 $ mint install yonaskolb/XcodeGen # install newest tag
 $ mint install yonaskolb/XcodeGen@master --force #reinstall the master branch
 $ mint run yonaskolb/XcodeGen@1.2.4 # run 1.2.4
 $ mint run XcodeGen # use newest tag and find XcodeGen in installed packages
 ```
 
-### Global installs
-By default Mint symlinks your installs into `usr/local/bin` when `install` or `update` are used, unless `--prevent-global` is passed. This means a package will be accessible from anywhere, and you don't have to prepend commands with `mint run package`. Note that only one global version can be installed at a time though. If you need to run a specific older version use `mint run`.
+### Linking
+By default Mint symlinks your installs into `usr/local/bin` on `mint install`, unless `--no-link` is passed. This means a package will be accessible from anywhere, and you don't have to prepend commands with `mint run package`. Note that only one linked version can be used at a time though. If you need to run a specific older version use `mint run`.
 
 ### Mintfile
 A `Mintfile` can specify a list of versioned packages. It makes installing and running these packages easy, as the specific repos and versions are centralized.
@@ -135,7 +134,7 @@ mint bootstrap
 
 ### Advanced
 - You can use `--silent` in `mint run` to silence any output from mint itself. Useful if forwarding output somewhere else.
-- You can set `MINT_PATH` and `MINT_INSTALL_PATH` envs to configure where mint caches builds, and where it symlinks global installs. These default to `/usr/local/lib/mint` and `/usr/local/bin` respectively
+- You can set `MINT_PATH` and `MINT_LINK_PATH` envs to configure where mint caches builds, and where it symlinks global installs. These default to `/usr/local/lib/mint` and `/usr/local/bin` respectively
 - You can use `mint install --force` to reinstall a package even if it's already installed. This shouldn't be required unless you are pointing at a branch and want to update it.
 
 ### Linux

--- a/Sources/MintCLI/Commands/InstallCommand.swift
+++ b/Sources/MintCLI/Commands/InstallCommand.swift
@@ -6,7 +6,7 @@ import Utility
 class InstallCommand: PackageCommand {
 
     let executable = OptionalParameter()
-    let preventGlobal = Flag("-p", "--prevent-global", description: "Whether to prevent global installation")
+    let noLink = Flag("-n", "--no-link", description: "Whether to prevent global linkage")
     let force = Flag("-f", "--force", description: "Force a reinstall even if the package is already installed", defaultValue: false)
 
     init(mint: Mint) {
@@ -17,7 +17,7 @@ class InstallCommand: PackageCommand {
     }
 
     override func execute(package: PackageReference) throws {
-        let global = !preventGlobal.value
-        try mint.install(package: package, executable: executable.value, force: force.value, global: global)
+        let link = !noLink.value
+        try mint.install(package: package, executable: executable.value, force: force.value, link: link)
     }
 }

--- a/Sources/MintCLI/Commands/ListCommand.swift
+++ b/Sources/MintCLI/Commands/ListCommand.swift
@@ -6,7 +6,7 @@ class ListCommand: MintCommand {
     init(mint: Mint) {
         super.init(mint: mint,
                    name: "list",
-                   description: "List all the currently installed packages. Globally installed packages are marked with *")
+                   description: "List all the currently installed packages. Globally linked packages are marked with *")
     }
 
     override func execute() throws {

--- a/Sources/MintCLI/MintCLI.swift
+++ b/Sources/MintCLI/MintCLI.swift
@@ -14,16 +14,16 @@ public class MintCLI {
     public init() {
 
         var mintPath: Path = "/usr/local/lib/mint"
-        var installationPath: Path = "/usr/local/bin"
+        var linkPath: Path = "/usr/local/bin"
 
         if let path = ProcessInfo.processInfo.environment["MINT_PATH"], !path.isEmpty {
             mintPath = Path(path)
         }
-        if let path = ProcessInfo.processInfo.environment["MINT_INSTALL_PATH"], !path.isEmpty {
-            installationPath = Path(path)
+        if let path = ProcessInfo.processInfo.environment["MINT_LINK_PATH"], !path.isEmpty {
+            linkPath = Path(path)
         }
 
-        mint = Mint(path: mintPath, installationPath: installationPath)
+        mint = Mint(path: mintPath, linkPath: linkPath)
 
         cli = CLI(name: "mint", version: version, description: "Run and install Swift Package Manager executables", commands: [
             RunCommand(mint: mint),

--- a/Tests/MintTests/MintTests.swift
+++ b/Tests/MintTests/MintTests.swift
@@ -6,7 +6,7 @@ import XCTest
 class MintTests: XCTestCase {
 
     let mint = Mint(path: Path.temporary + "mint",
-                    installationPath: Path.temporary + "mint-installs",
+                    linkPath: Path.temporary + "mint-installs",
                     standardOut: WriteStream.null,
                     standardError: WriteStream.null)
     let testRepo = "yonaskolb/SimplePackage"
@@ -21,65 +21,8 @@ class MintTests: XCTestCase {
         //mint.verbose = true
         mint.runAsNewProcess = false
         try? mint.path.delete()
-        try? mint.installationPath.delete()
+        try? mint.linkPath.delete()
         mint.mintFilePath = "Mintfile"
-    }
-
-    func testPackagePaths() {
-
-        let testMint = Mint(path: "/testPath/mint", installationPath: "/testPath/mint-installs")
-        let package = PackageReference(repo: "yonaskolb/mint", version: "1.2.0")
-        let packagePath = PackagePath(path: testMint.packagesPath, package: package)
-
-        XCTAssertEqual(testMint.path, "/testPath/mint")
-        XCTAssertEqual(testMint.packagesPath, "/testPath/mint/packages")
-        XCTAssertEqual(testMint.installationPath, "/testPath/mint-installs")
-        XCTAssertEqual(packagePath.gitPath, "https://github.com/yonaskolb/mint.git")
-        XCTAssertEqual(packagePath.repoPath, "github.com_yonaskolb_mint")
-        XCTAssertEqual(packagePath.packagePath, "/testPath/mint/packages/github.com_yonaskolb_mint")
-        XCTAssertEqual(packagePath.installPath, "/testPath/mint/packages/github.com_yonaskolb_mint/build/1.2.0")
-        XCTAssertEqual(packagePath.executablePath, "/testPath/mint/packages/github.com_yonaskolb_mint/build/1.2.0/mint")
-    }
-
-    func testPackageGitPaths() {
-
-        let urls: [String: String] = [
-            "yonaskolb/mint": "https://github.com/yonaskolb/mint.git",
-            "github.com/yonaskolb/mint": "https://github.com/yonaskolb/mint.git",
-            "https://github.com/yonaskolb/mint": "https://github.com/yonaskolb/mint",
-            "https://github.com/yonaskolb/mint.git": "https://github.com/yonaskolb/mint.git",
-            "mycustomdomain.com/package": "https://mycustomdomain.com/package",
-            "mycustomdomain.com/package.git": "https://mycustomdomain.com/package.git",
-            "https://mycustomdomain.com/package": "https://mycustomdomain.com/package",
-            "https://mycustomdomain.com/package.git": "https://mycustomdomain.com/package.git",
-            "git@github.com:yonaskolb/Mint.git": "git@github.com:yonaskolb/Mint.git",
-        ]
-
-        for (url, expected) in urls {
-            XCTAssertEqual(PackagePath.gitURLFromString(url), expected)
-        }
-    }
-
-    func testPackageReferenceInfo() {
-
-        XCTAssertEqual(PackageReference(package: "yonaskolb/mint"), PackageReference(repo: "yonaskolb/mint"))
-        XCTAssertEqual(PackageReference(package: "yonaskolb/mint@0.0.1"), PackageReference(repo: "yonaskolb/mint", version: "0.0.1"))
-        XCTAssertEqual(PackageReference(package: "github.com/yonaskolb/mint"), PackageReference(repo: "github.com/yonaskolb/mint"))
-        XCTAssertEqual(PackageReference(package: "github.com/yonaskolb/mint@0.0.1"), PackageReference(repo: "github.com/yonaskolb/mint", version: "0.0.1"))
-        XCTAssertEqual(PackageReference(package: "https://github.com/yonaskolb/mint"), PackageReference(repo: "https://github.com/yonaskolb/mint"))
-        XCTAssertEqual(PackageReference(package: "https://github.com/yonaskolb/mint@0.0.1"), PackageReference(repo: "https://github.com/yonaskolb/mint", version: "0.0.1"))
-        XCTAssertEqual(PackageReference(package: "https://github.com/yonaskolb/mint.git"), PackageReference(repo: "https://github.com/yonaskolb/mint.git"))
-        XCTAssertEqual(PackageReference(package: "https://github.com/yonaskolb/mint.git@0.0.1"), PackageReference(repo: "https://github.com/yonaskolb/mint.git", version: "0.0.1"))
-        XCTAssertEqual(PackageReference(package: "mycustomdomain.com/package"), PackageReference(repo: "mycustomdomain.com/package"))
-        XCTAssertEqual(PackageReference(package: "mycustomdomain.com/package@0.0.1"), PackageReference(repo: "mycustomdomain.com/package", version: "0.0.1"))
-        XCTAssertEqual(PackageReference(package: "mycustomdomain.com/package.git"), PackageReference(repo: "mycustomdomain.com/package.git"))
-        XCTAssertEqual(PackageReference(package: "mycustomdomain.com/package.git@0.0.1"), PackageReference(repo: "mycustomdomain.com/package.git", version: "0.0.1"))
-        XCTAssertEqual(PackageReference(package: "https://mycustomdomain.com/package"), PackageReference(repo: "https://mycustomdomain.com/package"))
-        XCTAssertEqual(PackageReference(package: "https://mycustomdomain.com/package@0.0.1"), PackageReference(repo: "https://mycustomdomain.com/package", version: "0.0.1"))
-        XCTAssertEqual(PackageReference(package: "https://mycustomdomain.com/package.git"), PackageReference(repo: "https://mycustomdomain.com/package.git"))
-        XCTAssertEqual(PackageReference(package: "https://mycustomdomain.com/package.git@0.0.1"), PackageReference(repo: "https://mycustomdomain.com/package.git", version: "0.0.1"))
-        XCTAssertEqual(PackageReference(package: "git@github.com:yonaskolb/Mint.git"), PackageReference(repo: "git@github.com:yonaskolb/Mint.git"))
-        XCTAssertEqual(PackageReference(package: "git@github.com:yonaskolb/Mint.git@0.0.1"), PackageReference(repo: "git@github.com:yonaskolb/Mint.git", version: "0.0.1"))
     }
 
     func checkInstalledVersion(package: PackageReference, executable: String, file: StaticString = #file, line: UInt = #line) throws {
@@ -91,7 +34,7 @@ class MintTests: XCTestCase {
 
     func testInstallCommand() throws {
 
-        let globalPath = mint.installationPath + testCommand
+        let globalPath = mint.linkPath + testCommand
 
         // install specific version
         let specificPackage = PackageReference(repo: testRepo, version: testVersion)
@@ -100,25 +43,25 @@ class MintTests: XCTestCase {
 
         // check that not globally installed
         XCTAssertFalse(globalPath.exists)
-        XCTAssertEqual(mint.getGlobalInstalledPackages(), [:])
+        XCTAssertEqual(mint.getLinkedPackages(), [:])
         // install already installed version globally
-        try mint.install(package: PackageReference(repo: testRepo, version: testVersion), global: true)
+        try mint.install(package: PackageReference(repo: testRepo, version: testVersion), link: true)
         XCTAssertTrue(globalPath.exists)
         let globalOutput = try capture(globalPath.string)
         XCTAssertEqual(globalOutput.stdout, testVersion)
 
-        XCTAssertEqual(mint.getGlobalInstalledPackages(), [testCommand: testVersion])
+        XCTAssertEqual(mint.getLinkedPackages(), [testCommand: testVersion])
 
         // install latest version
         let latestPackage = PackageReference(repo: testRepo)
-        try mint.install(package: latestPackage, executable: testCommand, global: true)
+        try mint.install(package: latestPackage, executable: testCommand, link: true)
         XCTAssertEqual(latestPackage.version, latestVersion)
         try checkInstalledVersion(package: latestPackage, executable: testCommand)
         XCTAssertEqual(latestPackage.version, latestVersion)
 
         let latestGlobalOutput = try capture(globalPath.string)
         XCTAssertEqual(latestGlobalOutput.stdout, latestVersion)
-        XCTAssertEqual(mint.getGlobalInstalledPackages(), [testCommand: latestVersion])
+        XCTAssertEqual(mint.getLinkedPackages(), [testCommand: latestVersion])
 
         // check package list has installed versions
         let installedPackages = try mint.listPackages()
@@ -130,7 +73,7 @@ class MintTests: XCTestCase {
 
         // check not globally installed
         XCTAssertFalse(globalPath.exists)
-        XCTAssertEqual(mint.getGlobalInstalledPackages(), [:])
+        XCTAssertEqual(mint.getLinkedPackages(), [:])
 
         // check package list is empty
         XCTAssertTrue(try mint.listPackages().isEmpty)
@@ -174,11 +117,11 @@ class MintTests: XCTestCase {
 
         let package = PackageReference(repo: "yonaskolb/SimplePackage", version: "4.0.0")
 
-        let globalPath = mint.installationPath + testCommand
+        let globalPath = mint.linkPath + testCommand
 
         // check that not globally installed
         XCTAssertFalse(globalPath.exists)
-        XCTAssertEqual(mint.getGlobalInstalledPackages(), [:])
+        XCTAssertEqual(mint.getLinkedPackages(), [:])
 
         let installedPackages = try mint.listPackages()
         XCTAssertEqual(installedPackages["SimplePackage", default: []], [package.version])

--- a/Tests/MintTests/PackageTests.swift
+++ b/Tests/MintTests/PackageTests.swift
@@ -1,0 +1,64 @@
+@testable import MintKit
+import PathKit
+import SwiftCLI
+import XCTest
+
+class PackageTests: XCTestCase {
+
+    func testPackagePaths() {
+
+        let testMint = Mint(path: "/testPath/mint", linkPath: "/testPath/mint-installs")
+        let package = PackageReference(repo: "yonaskolb/mint", version: "1.2.0")
+        let packagePath = PackagePath(path: testMint.packagesPath, package: package)
+
+        XCTAssertEqual(testMint.path, "/testPath/mint")
+        XCTAssertEqual(testMint.packagesPath, "/testPath/mint/packages")
+        XCTAssertEqual(testMint.linkPath, "/testPath/mint-installs")
+        XCTAssertEqual(packagePath.gitPath, "https://github.com/yonaskolb/mint.git")
+        XCTAssertEqual(packagePath.repoPath, "github.com_yonaskolb_mint")
+        XCTAssertEqual(packagePath.packagePath, "/testPath/mint/packages/github.com_yonaskolb_mint")
+        XCTAssertEqual(packagePath.installPath, "/testPath/mint/packages/github.com_yonaskolb_mint/build/1.2.0")
+        XCTAssertEqual(packagePath.executablePath, "/testPath/mint/packages/github.com_yonaskolb_mint/build/1.2.0/mint")
+    }
+
+    func testPackageGitPaths() {
+
+        let urls: [String: String] = [
+            "yonaskolb/mint": "https://github.com/yonaskolb/mint.git",
+            "github.com/yonaskolb/mint": "https://github.com/yonaskolb/mint.git",
+            "https://github.com/yonaskolb/mint": "https://github.com/yonaskolb/mint",
+            "https://github.com/yonaskolb/mint.git": "https://github.com/yonaskolb/mint.git",
+            "mycustomdomain.com/package": "https://mycustomdomain.com/package",
+            "mycustomdomain.com/package.git": "https://mycustomdomain.com/package.git",
+            "https://mycustomdomain.com/package": "https://mycustomdomain.com/package",
+            "https://mycustomdomain.com/package.git": "https://mycustomdomain.com/package.git",
+            "git@github.com:yonaskolb/Mint.git": "git@github.com:yonaskolb/Mint.git",
+            ]
+
+        for (url, expected) in urls {
+            XCTAssertEqual(PackagePath.gitURLFromString(url), expected)
+        }
+    }
+
+    func testPackageReferenceInfo() {
+
+        XCTAssertEqual(PackageReference(package: "yonaskolb/mint"), PackageReference(repo: "yonaskolb/mint"))
+        XCTAssertEqual(PackageReference(package: "yonaskolb/mint@0.0.1"), PackageReference(repo: "yonaskolb/mint", version: "0.0.1"))
+        XCTAssertEqual(PackageReference(package: "github.com/yonaskolb/mint"), PackageReference(repo: "github.com/yonaskolb/mint"))
+        XCTAssertEqual(PackageReference(package: "github.com/yonaskolb/mint@0.0.1"), PackageReference(repo: "github.com/yonaskolb/mint", version: "0.0.1"))
+        XCTAssertEqual(PackageReference(package: "https://github.com/yonaskolb/mint"), PackageReference(repo: "https://github.com/yonaskolb/mint"))
+        XCTAssertEqual(PackageReference(package: "https://github.com/yonaskolb/mint@0.0.1"), PackageReference(repo: "https://github.com/yonaskolb/mint", version: "0.0.1"))
+        XCTAssertEqual(PackageReference(package: "https://github.com/yonaskolb/mint.git"), PackageReference(repo: "https://github.com/yonaskolb/mint.git"))
+        XCTAssertEqual(PackageReference(package: "https://github.com/yonaskolb/mint.git@0.0.1"), PackageReference(repo: "https://github.com/yonaskolb/mint.git", version: "0.0.1"))
+        XCTAssertEqual(PackageReference(package: "mycustomdomain.com/package"), PackageReference(repo: "mycustomdomain.com/package"))
+        XCTAssertEqual(PackageReference(package: "mycustomdomain.com/package@0.0.1"), PackageReference(repo: "mycustomdomain.com/package", version: "0.0.1"))
+        XCTAssertEqual(PackageReference(package: "mycustomdomain.com/package.git"), PackageReference(repo: "mycustomdomain.com/package.git"))
+        XCTAssertEqual(PackageReference(package: "mycustomdomain.com/package.git@0.0.1"), PackageReference(repo: "mycustomdomain.com/package.git", version: "0.0.1"))
+        XCTAssertEqual(PackageReference(package: "https://mycustomdomain.com/package"), PackageReference(repo: "https://mycustomdomain.com/package"))
+        XCTAssertEqual(PackageReference(package: "https://mycustomdomain.com/package@0.0.1"), PackageReference(repo: "https://mycustomdomain.com/package", version: "0.0.1"))
+        XCTAssertEqual(PackageReference(package: "https://mycustomdomain.com/package.git"), PackageReference(repo: "https://mycustomdomain.com/package.git"))
+        XCTAssertEqual(PackageReference(package: "https://mycustomdomain.com/package.git@0.0.1"), PackageReference(repo: "https://mycustomdomain.com/package.git", version: "0.0.1"))
+        XCTAssertEqual(PackageReference(package: "git@github.com:yonaskolb/Mint.git"), PackageReference(repo: "git@github.com:yonaskolb/Mint.git"))
+        XCTAssertEqual(PackageReference(package: "git@github.com:yonaskolb/Mint.git@0.0.1"), PackageReference(repo: "git@github.com:yonaskolb/Mint.git", version: "0.0.1"))
+    }
+}

--- a/Tests/MintTests/XCTestManifests.swift
+++ b/Tests/MintTests/XCTestManifests.swift
@@ -6,9 +6,6 @@ extension MintTests {
         ("testInstallCommand", testInstallCommand),
         ("testMintErrors", testMintErrors),
         ("testMintFileInstall", testMintFileInstall),
-        ("testPackageGitPaths", testPackageGitPaths),
-        ("testPackagePaths", testPackagePaths),
-        ("testPackageReferenceInfo", testPackageReferenceInfo),
         ("testRunCommand", testRunCommand),
     ]
 }
@@ -20,11 +17,20 @@ extension MintfileTests {
     ]
 }
 
+extension PackageTests {
+    static let __allTests = [
+        ("testPackageGitPaths", testPackageGitPaths),
+        ("testPackagePaths", testPackagePaths),
+        ("testPackageReferenceInfo", testPackageReferenceInfo),
+    ]
+}
+
 #if !os(macOS)
 public func __allTests() -> [XCTestCaseEntry] {
     return [
         testCase(MintTests.__allTests),
         testCase(MintfileTests.__allTests),
+        testCase(PackageTests.__allTests),
     ]
 }
 #endif


### PR DESCRIPTION
This renames `global` to `link` in the codebase. User facing changes are
- `MINT_INSTALL_PATH` env -> `MINT_LINK_PATH`
- `--prevent-global` -> `--no-link`