### PR TITLE
Resolve package references in correct order

### DIFF
--- a/Sources/MintKit/MintError.swift
+++ b/Sources/MintKit/MintError.swift
@@ -4,7 +4,6 @@ import SwiftCLI
 public enum MintError: Error, CustomStringConvertible, Equatable, LocalizedError {
     case packageNotFound(String)
     case repoNotFound(String)
-    case invalidRepo(String)
     case buildError(String)
     case missingExecutable
     case invalidExecutable(String)
@@ -16,7 +15,6 @@ public enum MintError: Error, CustomStringConvertible, Equatable, LocalizedError
         switch self {
         case let .packageNotFound(package): return "\(package.quoted) package not found"
         case let .repoNotFound(repo): return "Git repo not found at \(repo.quoted)"
-        case let .invalidRepo(repo): return "Invalid repo \(repo.quoted)"
         case let .cloneError(url, version): return "Couldn't clone \(url) \(version)"
         case let .buildError(error): return error
         case let .mintfileNotFound(path): return "\(path) not found"

--- a/Tests/MintTests/MintTests.swift
+++ b/Tests/MintTests/MintTests.swift
@@ -41,6 +41,9 @@ class MintTests: XCTestCase {
         try mint.install(package: specificPackage)
         try checkInstalledVersion(package: specificPackage, executable: testCommand)
 
+        // install using simple name
+        try mint.install(package: PackageReference(repo: testRepoName, version: testVersion))
+
         // check that not globally installed
         XCTAssertFalse(globalPath.exists)
         XCTAssertEqual(mint.getLinkedPackages(), [:])
@@ -85,6 +88,9 @@ class MintTests: XCTestCase {
         let specificPackage = PackageReference(repo: testRepo, version: testVersion)
         try mint.run(package: specificPackage, arguments: [testCommand])
         try checkInstalledVersion(package: specificPackage, executable: testCommand)
+
+        // run using simple name
+        try mint.run(package: PackageReference(repo: testRepoName, version: testVersion), arguments: [])
 
         // run an already installed version
         try mint.run(package: PackageReference(repo: testRepo, version: testVersion), arguments: [testCommand])
@@ -133,8 +139,18 @@ class MintTests: XCTestCase {
     func testMintFileInstall() throws {
         mint.mintFilePath = simpleMintFileFixture.absolute()
 
-        let specificPackage = PackageReference(repo: testRepo)
+        let specificPackage = PackageReference(repo: testRepoName)
         try mint.install(package: specificPackage)
+        XCTAssertEqual(specificPackage.version, testVersion)
+        try checkInstalledVersion(package: specificPackage, executable: testCommand)
+    }
+
+    func testMintFileRun() throws {
+        mint.mintFilePath = simpleMintFileFixture.absolute()
+
+        let specificPackage = PackageReference(repo: testRepoName)
+        try mint.run(package: specificPackage, arguments: [])
+        XCTAssertEqual(specificPackage.version, testVersion)
         try checkInstalledVersion(package: specificPackage, executable: testCommand)
     }
 
@@ -142,10 +158,6 @@ class MintTests: XCTestCase {
 
         expectError(MintError.cloneError(url: "http://invaliddomain.com/invalid", version: testVersion)) {
             try mint.run(package: PackageReference(repo: "http://invaliddomain.com/invalid", version: testVersion), arguments: ["invalid"])
-        }
-
-        expectError(MintError.invalidRepo("invalid repo")) {
-            try mint.install(package: PackageReference(repo: "invalid repo", version: testVersion), force: false)
         }
 
         expectError(MintError.invalidExecutable("invalidCommand")) {


### PR DESCRIPTION
- Fixes #99
- Enables `mint install` to use package lookup by name. So if `realm/swiftlint` is installed then you can do `mint install swiftlint`
