### PR TITLE
Allow Swift compiler and linker flags to be passed through

### DIFF
--- a/Sources/MintCLI/Commands/InstallCommand.swift
+++ b/Sources/MintCLI/Commands/InstallCommand.swift
@@ -18,6 +18,6 @@ class InstallCommand: PackageCommand {
 
     override func execute(package: PackageReference) throws {
         let link = !noLink.value
-        try mint.install(package: package, executable: executable.value, force: force.value, link: link)
+        try mint.install(package: package, executable: executable.value, force: force.value, link: link, swiftCompilerFlags: swiftCompilerFlags.values, cCompilerFlags: cCompilerFlags.values, linkerFlags: linkerFlags.values)
     }
 }

--- a/Sources/MintCLI/Commands/PackageCommand.swift
+++ b/Sources/MintCLI/Commands/PackageCommand.swift
@@ -7,6 +7,9 @@ class PackageCommand: MintfileCommand {
 
     var package = Parameter()
     var silent = Flag("-s", "--silent", description: "Silences any output from Mint itself")
+    var swiftCompilerFlags = VariadicKey<String>("--Xswiftc", description: "Flag passed through to all Swift compiler invocations")
+    var cCompilerFlags = VariadicKey<String>("--Xcc", description: "Flag passed through to all C compiler invocations")
+    var linkerFlags = VariadicKey<String>("--Xlinker", description: "Flags passed through to all linker invocations")
 
     init(mint: Mint, name: String, description: String, parameterDescription: String? = nil) {
         var longDescription = """

--- a/Sources/MintCLI/Commands/RunCommand.swift
+++ b/Sources/MintCLI/Commands/RunCommand.swift
@@ -14,6 +14,6 @@ class RunCommand: PackageCommand {
     }
 
     override func execute(package: PackageReference) throws {
-        try mint.run(package: package, arguments: arguments.value)
+        try mint.run(package: package, arguments: arguments.value, swiftCompilerFlags: swiftCompilerFlags.values, cCompilerFlags: cCompilerFlags.values, linkerFlags: linkerFlags.values)
     }
 }

--- a/Sources/MintKit/Mint.swift
+++ b/Sources/MintKit/Mint.swift
@@ -173,12 +173,12 @@ public class Mint {
         }
     }
 
-    public func run(package: PackageReference, arguments: [String] = []) throws {
+    public func run(package: PackageReference, arguments: [String] = [], swiftCompilerFlags: [String] = [], cCompilerFlags: [String] = [], linkerFlags: [String] = []) throws {
 
         try resolvePackage(package)
 
         // install the package if not installed already
-        try install(package: package, force: false, link: false)
+        try install(package: package, force: false, link: false, swiftCompilerFlags: swiftCompilerFlags, cCompilerFlags: cCompilerFlags, linkerFlags: linkerFlags)
 
         var packagePath = PackagePath(path: packagesPath, package: package)
 
@@ -213,7 +213,7 @@ public class Mint {
         }
     }
 
-    public func install(package: PackageReference, executable: String? = nil, force: Bool = false, link: Bool = false) throws {
+    public func install(package: PackageReference, executable: String? = nil, force: Bool = false, link: Bool = false, swiftCompilerFlags: [String] = [], cCompilerFlags: [String] = [], linkerFlags: [String] = []) throws {
 
         try resolvePackage(package)
 
@@ -271,7 +271,7 @@ public class Mint {
 
         standardOut <<< "🌱  Building \(spmPackage.name) Package with SPM..."
 
-        try buildPackage(name: package.name, path: packageCheckoutPath)
+        try buildPackage(name: package.name, path: packageCheckoutPath, swiftCompilerFlags: swiftCompilerFlags, cCompilerFlags: cCompilerFlags, linkerFlags: linkerFlags)
 
         standardOut <<< "🌱  Installing \(spmPackage.name)..."
 
@@ -324,14 +324,23 @@ public class Mint {
         }
     }
 
-    private func buildPackage(name: String, path: Path) throws {
-
+    private func buildPackage(name: String, path: Path, swiftCompilerFlags: [String], cCompilerFlags: [String], linkerFlags: [String]) throws {
+        
         var command = "swift build -c release"
         #if os(macOS)
             let osVersion = ProcessInfo.processInfo.operatingSystemVersion
             let target = "x86_64-apple-macosx\(osVersion.majorVersion).\(osVersion.minorVersion)"
             command += " -Xswiftc -static-stdlib -Xswiftc -target -Xswiftc \(target)"
         #endif
+        for swiftCompilerFlag in swiftCompilerFlags {
+            command += " -Xswiftc \(swiftCompilerFlag)"
+        }
+        for cCompilerFlag in cCompilerFlags {
+            command += " -Xcc \(cCompilerFlag)"
+        }
+        for linkerFlag in linkerFlags {
+            command += " -Xlinker \(linkerFlag)"
+        }
 
 //        let buildSteps = [
 //            "Fetching": "Fetching Dependencies",


### PR DESCRIPTION
What:
---
I have a project that I want to distribute using Mint, but this project requires linker and compiler flags to be passed to the Swift compiler so that it can properly interface with a 3rd party library.

How:
---
This PR adds the ability for Mint to take variadic -Xcc and -Xlinker flags and pass them through to the invocation of `swift build`.

Let me know if this seems like a reasonable change and if there are any other steps I need to take to get this merged 😄 