### PR TITLE
make it simply pass capture error

### DIFF
--- a/Sources/MintKit/Mint.swift
+++ b/Sources/MintKit/Mint.swift
@@ -260,9 +260,7 @@ public class Mint {
             throw MintError.cloneError(url: packagePath.gitPath, version: package.version)
         }
 
-        guard let spmPackage = try? SwiftPackage(directory: packageCheckoutPath) else {
-            throw MintError.packageFileNotFound
-        }
+        let spmPackage = try SwiftPackage(directory: packageCheckoutPath)
 
         let executables = spmPackage.products.filter { $0.isExecutable }.map { $0.name }
         guard !executables.isEmpty else {


### PR DESCRIPTION
When fail to initialize SwiftPackage in install command, it just passed `MintError.packageFileNotFound` before.
However, this can happen not only because the file's absence but also invalid `Package.swift` status or other reason related with `Package.swift` faults.
So I think it shouldn't be expressed as Mint's domestic error, should pass the CaptureError or so.
Please condider merging this!

#114 