### PR TITLE
make Product compatible with Swift/SPM 5.0

### DIFF
--- a/Sources/MintKit/SwiftPackage.swift
+++ b/Sources/MintKit/SwiftPackage.swift
@@ -31,16 +31,40 @@ struct SwiftPackage: Decodable {
     }
 
     struct Product: Decodable {
+        
+        #if swift(>=5.0)
+        
+        struct ProductType: Decodable {
+            let executable: String?
+            let library:[String]?
+        }
+        
+        let name: String
+        let type: ProductType
+
+        enum CodingKeys: String, CodingKey {
+            case name
+            case type
+        }
+
+        var isExecutable: Bool {
+            return (type.library ?? []).count == 0
+        }
+        
+        #else
+        
         let name: String
         let type: String
-
+        
         enum CodingKeys: String, CodingKey {
             case name
             case type = "product_type"
         }
-
+        
         var isExecutable: Bool {
             return type == "executable"
         }
+        
+        #endif
     }
 }


### PR DESCRIPTION
as discussed in #129, Mint is not currently compatible with new SPM.

Seems like the new `dump-package` is returning products differently than before, specifically:

- when product is executable, type is 
```javascript
"type": {
 "executable": null
}
```
- when product is library, type is
```javascript
"type": {
"library":["static"]
}
```

that's why I'm currently checking the `isExecutable` var in that way.

Unit tests are currently failing (but they were failing anyway) and probably need further investigation.