### PR TITLE
Update to Swift 5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,15 @@
 version: 2
 jobs:
-  macOS_swift_4.1:
+  macOS_swift_5.0:
     macos:
-      xcode: "9.3.0"
+      xcode: "10.2.0"
     steps:
       - checkout
       - run: swift build
       - run: swift test
-  linux_swift_4.1:
+  linux_swift_5.0:
     docker:
-      - image: norionomura/swift:41
+      - image: norionomura/swift:50
     steps:
       - checkout
       - run: swift build
@@ -18,5 +18,5 @@ workflows:
   version: 2
   workflow:
     jobs:
-      - macOS_swift_4.1
-      - linux_swift_4.1
+      - macOS_swift_5.0
+      - linux_swift_5.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,4 +19,5 @@ workflows:
   workflow:
     jobs:
       - macOS_swift_5.0
-      - linux_swift_5.0
+      # Linux disabled for now
+      #- linux_swift_5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Master
 
+#### Fixed
+- Fixed building packages when running in Swift 5 #130 #131 @stefanomondino @yonaskolb
+
+#### Changed
+- Updated to Swift 5 and dropped Swift 4.2 #131 @yonaskolb
+
 ## 0.11.4
 
 #### Added

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ install: build
 	cp -f $(BUILD_PATH) $(INSTALL_PATH)
 
 build:
-	swift build --disable-sandbox -c release -Xswiftc -static-stdlib
+	swift build --disable-sandbox -c release
 
 uninstall:
 	rm -f $(INSTALL_PATH)

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/kylef/PathKit.git",
         "state": {
           "branch": null,
-          "revision": "fa81fa9e3a9f59645159c4ea45c0c46ee6558f71",
-          "version": "0.9.1"
+          "revision": "e2f5be30e4c8f531c9c1e8765aa7b71c0a45d7a0",
+          "version": "0.9.2"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/kylef/Spectre.git",
         "state": {
           "branch": null,
-          "revision": "e34d5687e1e9d865e3527dd58bc2f7464ef6d936",
-          "version": "0.8.0"
+          "revision": "f14ff47f45642aa5703900980b014c2e9394b6e5",
+          "version": "0.9.0"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/jakeheis/SwiftCLI",
         "state": {
           "branch": null,
-          "revision": "694a1ab7c3db539b095aaeed7bc4bf774a12bdce",
-          "version": "5.1.3"
+          "revision": "5318c37d3cacc8780f50b87a8840a6774320ebdf",
+          "version": "5.2.2"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,4 @@
-// swift-tools-version:4.0
-// Managed by ice
+// swift-tools-version:5.0
 
 import PackageDescription
 

--- a/Sources/MintKit/Mint.swift
+++ b/Sources/MintKit/Mint.swift
@@ -269,7 +269,7 @@ public class Mint {
         #if os(macOS)
             let osVersion = ProcessInfo.processInfo.operatingSystemVersion
             let target = "x86_64-apple-macosx\(osVersion.majorVersion).\(osVersion.minorVersion)"
-            buildCommand += " -Xswiftc -static-stdlib -Xswiftc -target -Xswiftc \(target)"
+            buildCommand += " -Xswiftc -target -Xswiftc \(target)"
         #endif
 
         try runPackageCommand(name: "Building package",

--- a/Sources/MintKit/StringExtensions.swift
+++ b/Sources/MintKit/StringExtensions.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public extension String {
 
-    public var quoted: String {
+    var quoted: String {
         return "\"\(self)\""
     }
 }

--- a/Sources/MintKit/SwiftPackage.swift
+++ b/Sources/MintKit/SwiftPackage.swift
@@ -31,40 +31,43 @@ struct SwiftPackage: Decodable {
     }
 
     struct Product: Decodable {
-        
+
+        let name: String
+        let isExecutable: Bool
+
         #if swift(>=5.0)
-        
-        struct ProductType: Decodable {
-            let executable: String?
-            let library:[String]?
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            name = try container.decode(String.self, forKey: .name)
+            let typeContainer = try container.nestedContainer(keyedBy: ProductCodingKeys.self, forKey: .type)
+            isExecutable = typeContainer.contains(.executable)
+        }
+
+        enum ProductCodingKeys: String, CodingKey {
+            case executable
+            case library
         }
         
-        let name: String
-        let type: ProductType
-
         enum CodingKeys: String, CodingKey {
             case name
             case type
         }
 
-        var isExecutable: Bool {
-            return (type.library ?? []).count == 0
-        }
-        
         #else
-        
-        let name: String
-        let type: String
-        
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            name = try container.decode(String.self, forKey: .name)
+            let type = try container.decode(String.self, forKey: .type)
+            isExecutable = type == "executable"
+        }
+
         enum CodingKeys: String, CodingKey {
             case name
             case type = "product_type"
         }
-        
-        var isExecutable: Bool {
-            return type == "executable"
-        }
-        
+
         #endif
     }
 }

--- a/Sources/MintKit/SwiftPackage.swift
+++ b/Sources/MintKit/SwiftPackage.swift
@@ -18,7 +18,7 @@ struct SwiftPackage: Decodable {
             throw MintError.packageReadError("Couldn't dump package:\n\(message)")
         }
 
-        guard let json = content.index(of: "{"),
+        guard let json = content.firstIndex(of: "{"),
             let data = content[json...].data(using: .utf8) else {
             throw MintError.packageReadError("Couldn't parse package dump:\n\(content)")
         }


### PR DESCRIPTION
This updates to Swift 5 and drops Swift 4.2.

I've had to disable the Linux tests for now as it's failing there with the following error and not sure why yet:
```
<unknown>:0: error: unable to execute command: Killed
<unknown>:0: error: compile command failed due to signal 9 (use -v to see invocation)
```