### PR TITLE
Added outdated + update commands

### DIFF
--- a/Sources/MintCLI/Commands/OutdatedCommand.swift
+++ b/Sources/MintCLI/Commands/OutdatedCommand.swift
@@ -1,0 +1,16 @@
+import Foundation
+import MintKit
+
+class OutdatedCommand: MintCommand {
+    
+    init(mint: Mint) {
+        super.init(mint: mint,
+                   name: "outdated",
+                   description: "List all the currently installed and linked packages that are outdated.")
+    }
+    
+    override func execute() throws {
+        try super.execute()
+        try mint.outdated()
+    }
+}

--- a/Sources/MintCLI/Commands/UpdateCommand.swift
+++ b/Sources/MintCLI/Commands/UpdateCommand.swift
@@ -1,0 +1,16 @@
+import Foundation
+import MintKit
+
+class UpdateCommand: MintCommand {
+    
+    init(mint: Mint) {
+        super.init(mint: mint,
+                   name: "update",
+                   description: "Updates all currently installed and linked packages that are outdated.")
+    }
+    
+    override func execute() throws {
+        try super.execute()
+        try mint.update()
+    }
+}

--- a/Sources/MintCLI/MintCLI.swift
+++ b/Sources/MintCLI/MintCLI.swift
@@ -31,6 +31,8 @@ public class MintCLI {
             UninstallCommand(mint: mint),
             ListCommand(mint: mint),
             BootstrapCommand(mint: mint),
+            OutdatedCommand(mint: mint),
+            UpdateCommand(mint: mint)
         ])
     }
 

--- a/Sources/MintKit/Mint.swift
+++ b/Sources/MintKit/Mint.swift
@@ -130,7 +130,7 @@ public class Mint {
         return versionsByPackage
     }
 
-    func resolvePackage(_ package: PackageReference) throws {
+    func resolvePackage(_ package: PackageReference, silent: Bool = false) throws {
 
         // resolve version from MintFile
         if package.version.isEmpty,
@@ -140,7 +140,9 @@ public class Mint {
             if let mintFilePackage = mintfile.package(for: package.repo), !mintFilePackage.version.isEmpty {
                 package.version = mintFilePackage.version
                 package.repo = mintFilePackage.repo
-                output("Using \(package.repo) \(package.version) from Mintfile.")
+                if !silent {
+                    output("Using \(package.repo) \(package.version) from Mintfile.")
+                }
             }
         }
 
@@ -157,7 +159,9 @@ public class Mint {
         // resove latest version from git repo
         if package.version.isEmpty {
             // we don't have a specific version, let's get the latest tag
-            output("Finding latest version of \(package.name)")
+            if !silent {
+                output("Finding latest version of \(package.name)")
+            }
             do {
                 let tagOutput = try SwiftCLI.capture(bash: "git ls-remote --tags --refs \(package.gitPath)")
 
@@ -449,5 +453,53 @@ public class Mint {
             }
         }
         try? installPath.delete()
+    }
+    
+    @discardableResult
+    public func outdated(silent: Bool = false) throws -> [String : (oldVersion: String, newReference: PackageReference) ] {
+        guard packagesPath.exists else {
+            if !silent {
+                output("No mint packages installed")
+            }
+            return [:]
+        }
+
+        var outdatedPackageReferences: [String:  (oldVersion: String, newReference: PackageReference)] = [:]
+        let outdatedPackages: [String] = try getLinkedPackages().compactMap { (name, version) in
+            guard let gitRepo = try getPackageGit(name: name) else {
+                return nil
+            }
+            let reference = PackageReference(repo: gitRepo)
+            try resolvePackage(reference, silent: true)
+            if reference.version > version {
+                outdatedPackageReferences[name] =  (oldVersion: version, newReference: reference)
+                return "\(name): \(version) < \(reference.version)"
+            } else {
+                return nil
+            }
+        }.sorted { $0.localizedStandardCompare($1) == .orderedAscending }
+        
+        if outdatedPackages.isEmpty {
+            if !silent {
+                output("All packages are up to date")
+            }
+        } else {
+            if !silent {
+                output("Outdated mint packages:\n\(outdatedPackages.joined(separator: "\n"))")
+            }
+        }
+        return outdatedPackageReferences
+    }
+    
+    public func update() throws {
+        let outdatedPackages = try outdated(silent: true)
+        guard !outdatedPackages.isEmpty  else {
+            output("All packages are already up to date")
+            return
+        }
+        for (name, value) in outdatedPackages {
+            try install(package: value.newReference, executable: name, force: true, link: true)
+            output("Updated \(value.newReference.name) from version \(value.oldVersion) to \(value.newReference.version)")
+        }
     }
 }

--- a/Tests/MintTests/MintTests.swift
+++ b/Tests/MintTests/MintTests.swift
@@ -10,6 +10,7 @@ class MintTests: XCTestCase {
                     standardOut: WriteStream.null,
                     standardError: WriteStream.null)
     let testRepo = "yonaskolb/SimplePackage"
+    let gitTestRepo = "https://github.com/yonaskolb/SimplePackage.git"
     let sshTestRepo = "git@github.com:yonaskolb/SimplePackage.git"
     let testVersion = "4.0.0"
     let latestVersion = "5.0.0"
@@ -188,5 +189,31 @@ class MintTests: XCTestCase {
         expectError(MintError.packageBuildError(PackageReference(repo: "yonaskolb/simplepackage", version: "compile_error"))) {
             try mint.install(package: PackageReference(repo: "yonaskolb/simplepackage", version: "compile_error"))
         }
+    }
+    
+    func testOutdated() throws {
+        let specificPackage = PackageReference(repo: testRepo, version: testVersion)
+        let updatedPackage = PackageReference(repo: gitTestRepo, version: latestVersion)
+        try mint.install(package: specificPackage, link: true)
+        let outdatedResult = try mint.outdated()
+        XCTAssertEqual(outdatedResult.count, 1)
+        let result = outdatedResult["simplepackage"]!
+        XCTAssertEqual(result.oldVersion, testVersion)
+        XCTAssertEqual(result.newReference, updatedPackage)
+        
+        try mint.install(package: updatedPackage, force: true, link: true)
+        let outdatedResultAfterLatestInstallation = try mint.outdated()
+        XCTAssertEqual(outdatedResultAfterLatestInstallation.count, 0)
+    }
+    
+    func testUpdate() throws {
+        let specificPackage = PackageReference(repo: testRepo, version: testVersion)
+        try mint.install(package: specificPackage, link: true)
+        let outdatedResult = try mint.outdated()
+        XCTAssertEqual(outdatedResult.count, 1)
+        
+        try mint.update()
+        let outdatedResultAfterLatestInstallation = try mint.outdated()
+        XCTAssertEqual(outdatedResultAfterLatestInstallation.count, 0)
     }
 }


### PR DESCRIPTION
This PR adds two commands:
- outdated: returns all linked packages that are not up to date
- update: reinstall all outdated packages

fixes #87, #121  