### PR TITLE
Added the option to link the packages of a mintfile globally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Master
 
+#### Added
+
+- Added the `--link` (or `-l`) flag to the `bootstrap` option, to optionally link the packages of a `Mintfile` globally [#137](https://github.com/yonaskolb/Mint/pull/137) @acecilia
+
 ## 0.12.0
 
 #### Fixed

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Run `mint help` to see usage instructions.
 - **run**: Runs a package. This will install it first if it isn't already installed, though won't link it globally. It's useful for running a certain version.
 - **list**: Lists all currently installed packages and versions.
 - **uninstall**: Uninstalls a package by name.
-- **bootstrap**: Installs all the packages in your [Mintfile](#mintfile) without linking them globally
+- **bootstrap**: Installs all the packages in your [Mintfile](#mintfile), by default, without linking them globally
 
 **Package reference**
 
@@ -129,10 +129,16 @@ Then you can simply run a package with:
 mint run xcodegen
 ```
 
-Or install all the packages in one go with:
+Or install all the packages (without linking them globally) in one go with:
 
 ```sh
 mint bootstrap
+```
+
+If you prefer to link them globally, do such with:
+
+```sh
+mint bootstrap --link
 ```
 
 ### Advanced

--- a/Sources/MintCLI/Commands/BootstrapCommand.swift
+++ b/Sources/MintCLI/Commands/BootstrapCommand.swift
@@ -14,6 +14,6 @@ class BootstrapCommand: MintfileCommand {
 
     override func execute() throws {
         try super.execute()
-        try mint.bootstrap()
+        try mint.bootstrap(link: link.value)
     }
 }

--- a/Sources/MintCLI/Commands/MintFileCommand.swift
+++ b/Sources/MintCLI/Commands/MintFileCommand.swift
@@ -7,6 +7,7 @@ import SwiftCLI
 class MintfileCommand: MintCommand {
 
     var verbose = Flag("-v", "--verbose", description: "Show verbose output", defaultValue: false)
+    var link = Flag("-l", "--link", description: "Install the packages of the Mintfile globally", defaultValue: false)
     var mintFile = Key<String>("-m", "--mintfile", description: "Custom path to a Mintfile. Defaults to Mintfile")
 
     override func execute() throws {

--- a/Sources/MintKit/Mint.swift
+++ b/Sources/MintKit/Mint.swift
@@ -388,7 +388,7 @@ public class Mint {
         output(confirmation.green)
     }
 
-    public func bootstrap() throws {
+    public func bootstrap(link: Bool = false) throws {
 
         let mintFile = try Mintfile(path: mintFilePath)
 
@@ -401,7 +401,7 @@ public class Mint {
 
         output("Found \(packageCount) in \(mintFilePath.string)")
         for package in mintFile.packages {
-            try install(package: package, force: false, link: false)
+            try install(package: package, force: false, link: link)
         }
         output("Installed \(packageCount) from \(mintFilePath.string)".green)
     }

--- a/Tests/MintTests/MintTests.swift
+++ b/Tests/MintTests/MintTests.swift
@@ -136,6 +136,26 @@ class MintTests: XCTestCase {
         try checkInstalledVersion(package: package, executable: testCommand)
     }
 
+    func testBootstrapCommandLinkingGlobally() throws {
+        mint.mintFilePath = simpleMintFileFixture.absolute()
+
+        try mint.bootstrap(link: true)
+
+        let package = PackageReference(repo: "yonaskolb/SimplePackage", version: "4.0.0")
+
+        let globalPath = mint.linkPath + testCommand
+
+        // check that is globally installed
+        XCTAssertTrue(globalPath.exists)
+        XCTAssertEqual(mint.getLinkedPackages(), [testCommand: package.version])
+
+        let installedPackages = try mint.listPackages()
+        XCTAssertEqual(installedPackages["SimplePackage", default: []], [package.version])
+        XCTAssertEqual(installedPackages.count, 1)
+
+        try checkInstalledVersion(package: package, executable: testCommand)
+    }
+
     func testMintFileInstall() throws {
         mint.mintFilePath = simpleMintFileFixture.absolute()
 

--- a/Tests/MintTests/MintTests.swift
+++ b/Tests/MintTests/MintTests.swift
@@ -130,7 +130,7 @@ class MintTests: XCTestCase {
         XCTAssertEqual(mint.getLinkedPackages(), [:])
 
         let installedPackages = try mint.listPackages()
-        XCTAssertEqual(installedPackages["SimplePackage", default: []], [package.version])
+        XCTAssertEqual(installedPackages[package.name, default: []], [package.version])
         XCTAssertEqual(installedPackages.count, 1)
 
         try checkInstalledVersion(package: package, executable: testCommand)
@@ -145,12 +145,12 @@ class MintTests: XCTestCase {
 
         let globalPath = mint.linkPath + testCommand
 
-        // check that is globally installed
+        // Check that is globally installed
         XCTAssertTrue(globalPath.exists)
         XCTAssertEqual(mint.getLinkedPackages(), [testCommand: package.version])
 
         let installedPackages = try mint.listPackages()
-        XCTAssertEqual(installedPackages["SimplePackage", default: []], [package.version])
+        XCTAssertEqual(installedPackages[package.name, default: []], [package.version])
         XCTAssertEqual(installedPackages.count, 1)
 
         try checkInstalledVersion(package: package, executable: testCommand)


### PR DESCRIPTION
Solves https://github.com/yonaskolb/Mint/issues/136.

The new flag added is `-l` or `--link`.

Usage:
`mint bootstrap --link`.

For the next major version it may be good to align what is the default behaviour. At the moment:
- `install`: links globally by default.
- `bootstrap`: does not link globally by default.
