### PR TITLE
Add Docker Support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.build
+.dockerignore
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# Build stage
+FROM swift:5.0 AS build
+
+# Build Mint
+COPY . /Mint
+WORKDIR /Mint
+RUN swift build --disable-sandbox -c release
+
+# Release stage
+FROM swift:5.0 AS release
+
+# Copy Mint executable from build stage
+COPY --from=build /Mint/.build/release/mint /usr/local/bin


### PR DESCRIPTION
**Background:**
Mint is a great tool and it is helpful to use it in CI to install tools like SwiftLint. It would be nice if Mint had docker support to avoid having to manually set up Mint in CI. This has also been requested in #128.

**Implementation:**
Added a basic `Dockerfile`. This will create a docker image with Mint installed at `/usr/local/bin`.
An image can be created by running `docker build -t <name> .` when in the root directory of this project.

**Question:**
Would you be able to publish the image to [Docker Hub](https://hub.docker.com/) so it can easily be used by other people?