### PR TITLE
Fix #145 Required to type command twice when attempting to execute a subcommand

### DIFF
--- a/Sources/MintCLI/Commands/MintFileCommand.swift
+++ b/Sources/MintCLI/Commands/MintFileCommand.swift
@@ -1,4 +1,3 @@
-
 import Foundation
 import MintKit
 import PathKit

--- a/Sources/MintKit/Mint.swift
+++ b/Sources/MintKit/Mint.swift
@@ -188,25 +188,25 @@ public class Mint {
 
         var packagePath = PackagePath(path: packagesPath, package: package)
 
-        if let packageExecutable = arguments.first {
-            packagePath.executable = packageExecutable
-            if !packagePath.executablePath.exists {
-                throw MintError.invalidExecutable(packageExecutable)
-            }
-        } else {
-            let executables = try packagePath.getExecutables()
-            switch executables.count {
-            case 0:
-                throw MintError.missingExecutable(package)
-            case 1:
-                packagePath.executable = executables[0]
-            default:
-                packagePath.executable = inputReader.ask("There are multiple executables, which one would you like to run?", answers: executables)
-            }
+        let executables = try packagePath.getExecutables()
+        let executable: String
+        switch executables.count {
+        case 0:
+          throw MintError.missingExecutable(package)
+        case 1:
+          executable = executables[0]
+        default:
+          executable = inputReader.ask("There are multiple executables, which one would you like to run?", answers: executables)
         }
-        output("Running \(packagePath.executable ?? "") \(package.version)...")
 
-        let arguments = arguments.isEmpty ? [] : Array(arguments.dropFirst())
+        packagePath.executable = executable
+
+        // Is this actually possible since we're using "packagePath.getExecutables()"?
+        guard packagePath.executablePath.exists else {
+          throw MintError.invalidExecutable(executable)
+        }
+
+        output("Running \(executable) \(package.version)...")
 
         if runAsNewProcess {
             var env = ProcessInfo.processInfo.environment

--- a/Tests/MintTests/MintTests.swift
+++ b/Tests/MintTests/MintTests.swift
@@ -180,10 +180,6 @@ class MintTests: XCTestCase {
             try mint.install(package: PackageReference(repo: "http://invaliddomain.com/invalid", version: testVersion))
         }
 
-        expectError(MintError.invalidExecutable("invalidCommand")) {
-            try mint.run(package: PackageReference(repo: testRepo, version: testVersion), arguments: ["invalidCommand"])
-        }
-
         expectError(MintError.packageNotFound("invalidPackage")) {
             try mint.run(package: PackageReference(repo: "invalidPackage", version: testVersion), arguments: [])
         }


### PR DESCRIPTION
### Summary
This is a fix for the problem detailed on #145

### Changes
* In the `run` command, uses the single executable available or ask the user to chose one of the available executables
* Using the parameter `arguments` sent to the `run` command as the arguments for the executable, without dropping the first argument