### PR TITLE
Installer cannot resolve gitPath using shortened GitHub repo name if repo has a period in its name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Master
 
+## 0.14.0
+
+#### Fixed
+- Fixed a bug that prevented the `Mintfile` from resolving a GitHub repository where the name contains a period [#153](https://github.com/yonaskolb/Mint/pull/153) @liamnichols
+
+[Commits](https://github.com/yonaskolb/Mint/compare/0.13.0...0.14.0)
+
 ## 0.13.0
 
 #### Added

--- a/Sources/MintKit/PackageReference.swift
+++ b/Sources/MintKit/PackageReference.swift
@@ -42,7 +42,7 @@ public class PackageReference {
     }
 
     public var name: String {
-        return repo.components(separatedBy: "/").last!.components(separatedBy: ".").first!
+        return repo.components(separatedBy: "/").last!.replacingOccurrences(of: ".git", with: "")
     }
 
     public var gitPath: String {

--- a/Sources/MintKit/PackageReference.swift
+++ b/Sources/MintKit/PackageReference.swift
@@ -53,7 +53,7 @@ public class PackageReference {
                 return repo
             } else if repo.contains("github.com") {
                 return "https://\(repo).git"
-            } else if repo.contains(".") {
+            } else if repo.components(separatedBy: "/").first!.contains(".") {
                 return "https://\(repo)"
             } else {
                 return "https://github.com/\(repo).git"

--- a/Tests/MintTests/PackageTests.swift
+++ b/Tests/MintTests/PackageTests.swift
@@ -33,6 +33,7 @@ class PackageTests: XCTestCase {
             "https://mycustomdomain.com/package": "https://mycustomdomain.com/package",
             "https://mycustomdomain.com/package.git": "https://mycustomdomain.com/package.git",
             "git@github.com:yonaskolb/Mint.git": "git@github.com:yonaskolb/Mint.git",
+            "mac-cain13/R.swift": "https://github.com/mac-cain13/R.swift.git",
         ]
 
         for (url, expected) in urls {

--- a/Tests/MintTests/PackageTests.swift
+++ b/Tests/MintTests/PackageTests.swift
@@ -41,6 +41,29 @@ class PackageTests: XCTestCase {
         }
     }
 
+    func testPackageNames() {
+
+        let urls: [String: String] = [
+            "yonaskolb/mint": "mint",
+            "github.com/yonaskolb/mint": "mint",
+            "https://github.com/yonaskolb/mint": "mint",
+            "https://github.com/yonaskolb/mint.git": "mint",
+            "mycustomdomain.com/package": "package",
+            "mycustomdomain.com/package.git": "package",
+            "https://mycustomdomain.com/package": "package",
+            "https://mycustomdomain.com/package.git": "package",
+            "git@github.com:yonaskolb/Mint.git": "Mint",
+            "mac-cain13/R.swift": "R.swift",
+            "github.com/mac-cain13/R.swift": "R.swift",
+            "https://github.com/mac-cain13/R.swift.git": "R.swift",
+            "git@github.com:mac-cain13/R.swift.git": "R.swift",
+        ]
+
+        for (url, expected) in urls {
+            XCTAssertEqual(PackageReference(repo: url).name, expected)
+        }
+    }
+
     func testPackageReferenceInfo() {
 
         XCTAssertEqual(PackageReference(package: "yonaskolb/mint"), PackageReference(repo: "yonaskolb/mint"))


### PR DESCRIPTION
I'm trying to integrate the R.swift project into my Mintfile (https://github.com/mac-cain13/R.swift/issues/593) and I've done so using the shorthand syntax like this:

```
liamnichols/R.swift@ln/build-rule # (using a fork for a bugfix)
```

However upon trying to install via `mint bootstrap` I get the following: 

```
mint bootstrap
🌱  Found 2 packages in Mintfile
🌱  SwiftLint 0.38.0 already installed
🌱  Cloning R ln/build-rule
Cloning into 'liamnichols_R.swift'...
fatal: unable to access 'https://liamnichols/R.swift.git/': Could not resolve host: liamnichols
🌱  Encountered error during "git clone --depth 1 -b ln/build-rule https://liamnichols/R.swift.git liamnichols_R.swift". Use --verbose to see full output
🌱  Couldn't clone https://liamnichols/R.swift.git ln/build-rule
```

After digging through the source, it looks like there is some logic in the `gitPath` computed property to detect when the user specifies a custom non-github.com hostname without a url scheme (i.e `mycustomdomain.com/package`) and this was done by checking for a `.` in any part of the string. 

I'm not sure if this is the right approach since it seems a bit fragile, but I was able to work around the issue by checking that the first component of the repo string separated by `/` contains the period instead of the entire string. I've added an example and the tests verify that it hasn't caused any known regressions. 

I feel like there might be a nicer way to resolve this bug however I didn't want to spend too much time on it since I don't know exactly what are the valid formats. I raised this PR as a starting point but am happy to make further changes with some help 🙂 

Additionally, I also noticed that in the console log the name would also be printed incorrectly:

> ```
> 🌱  Cloning R ln/build-rule
> ```

My second commit patches this by doing `.replacingOccurrences(of: ".git", with: "")` instead of `components(separatedBy: ".").first!`. I don't think there are any other intended path components so this _should_ be ok? 

Thanks for all the great work on this! Let me know if I can do anything else to help with this issue 🙏 