### PR TITLE
Update to SwiftCLI 6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master
 
 #### Internal
+- Updated to SwiftCLI 6.0 [#157](https://github.com/yonaskolb/Mint/pull/157) @yonaskolb
 - Replace CircleCI with Github actions [#158](https://github.com/yonaskolb/Mint/pull/158) @yonaskolb
 
 ## 0.14.0

--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/jakeheis/SwiftCLI.git",
         "state": {
           "branch": null,
-          "revision": "ba2268e67c07b9f9cfbc0801385e6238b36255eb",
-          "version": "5.3.2"
+          "revision": "c72c4564f8c0a24700a59824880536aca45a4cae",
+          "version": "6.0.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/kylef/PathKit.git", from: "1.0.0"),
         .package(url: "https://github.com/onevcat/Rainbow.git", from: "3.1.0"),
-        .package(url: "https://github.com/jakeheis/SwiftCLI.git", from: "5.3.0"),
+        .package(url: "https://github.com/jakeheis/SwiftCLI.git", from: "6.0.0"),
         .package(url: "https://github.com/mxcl/Version.git", from: "1.1.0")
     ],
     targets: [

--- a/Sources/MintCLI/Commands/BootstrapCommand.swift
+++ b/Sources/MintCLI/Commands/BootstrapCommand.swift
@@ -14,6 +14,6 @@ class BootstrapCommand: MintfileCommand {
 
     override func execute() throws {
         try super.execute()
-        try mint.bootstrap(link: link.value)
+        try mint.bootstrap(link: link)
     }
 }

--- a/Sources/MintCLI/Commands/InstallCommand.swift
+++ b/Sources/MintCLI/Commands/InstallCommand.swift
@@ -4,9 +4,13 @@ import SwiftCLI
 
 class InstallCommand: PackageCommand {
 
-    let executable = OptionalParameter()
-    let noLink = Flag("-n", "--no-link", description: "Whether to prevent global linkage")
-    let force = Flag("-f", "--force", description: "Force a reinstall even if the package is already installed", defaultValue: false)
+    @Param var executable: String?
+
+    @Flag("-n", "--no-link", description: "Whether to prevent global linkage")
+    var noLink: Bool
+
+    @Flag("-f", "--force", description: "Force a reinstall even if the package is already installed")
+    var force: Bool
 
     init(mint: Mint) {
         super.init(mint: mint,
@@ -16,7 +20,7 @@ class InstallCommand: PackageCommand {
     }
 
     override func execute(package: PackageReference) throws {
-        let link = !noLink.value
-        try mint.install(package: package, executable: executable.value, force: force.value, link: link)
+        let link = !noLink
+        try mint.install(package: package, executable: executable, force: force, link: link)
     }
 }

--- a/Sources/MintCLI/Commands/MintFileCommand.swift
+++ b/Sources/MintCLI/Commands/MintFileCommand.swift
@@ -6,15 +6,20 @@ import SwiftCLI
 
 class MintfileCommand: MintCommand {
 
-    var verbose = Flag("-v", "--verbose", description: "Show verbose output", defaultValue: false)
-    var link = Flag("-l", "--link", description: "Install the packages of the Mintfile globally", defaultValue: false)
-    var mintFile = Key<String>("-m", "--mintfile", description: "Custom path to a Mintfile. Defaults to Mintfile")
+    @Flag("-v", "--verbose", description: "Show verbose output")
+    var verbose: Bool
+
+    @Flag("-l", "--link", description: "Install the packages of the Mintfile globally")
+    var link: Bool
+
+    @Key("-m", "--mintfile", description: "Custom path to a Mintfile. Defaults to Mintfile")
+    var mintFile: String?
 
     override func execute() throws {
         try super.execute()
 
-        mint.verbose = verbose.value
-        if let mintFile = mintFile.value {
+        mint.verbose = verbose
+        if let mintFile = mintFile {
             mint.mintFilePath = Path(mintFile)
         }
     }

--- a/Sources/MintCLI/Commands/PackageCommand.swift
+++ b/Sources/MintCLI/Commands/PackageCommand.swift
@@ -5,8 +5,10 @@ import SwiftCLI
 
 class PackageCommand: MintfileCommand {
 
-    var package = Parameter()
-    var silent = Flag("-s", "--silent", description: "Silences any output from Mint itself")
+    @Param var package: String
+
+    @Flag("-s", "--silent", description: "Silences any output from Mint itself")
+    var silent: Bool
 
     init(mint: Mint, name: String, description: String, parameterDescription: String? = nil) {
         var longDescription = """
@@ -23,13 +25,13 @@ class PackageCommand: MintfileCommand {
     }
 
     override func execute() throws {
-        if silent.value {
+        if silent {
             mint.standardOut = WriteStream.null
         }
 
         try super.execute()
 
-        let package = PackageReference(package: self.package.value)
+        let package = PackageReference(package: self.package)
         try execute(package: package)
     }
 

--- a/Sources/MintCLI/Commands/RunCommand.swift
+++ b/Sources/MintCLI/Commands/RunCommand.swift
@@ -4,7 +4,7 @@ import SwiftCLI
 
 class RunCommand: PackageCommand {
 
-    var arguments = OptionalCollectedParameter()
+    @CollectedParam var arguments: [String]
 
     init(mint: Mint) {
         super.init(mint: mint,
@@ -14,6 +14,6 @@ class RunCommand: PackageCommand {
     }
 
     override func execute(package: PackageReference) throws {
-        try mint.run(package: package, arguments: arguments.value)
+        try mint.run(package: package, arguments: arguments)
     }
 }

--- a/Sources/MintCLI/Commands/UninstallCommand.swift
+++ b/Sources/MintCLI/Commands/UninstallCommand.swift
@@ -4,7 +4,7 @@ import SwiftCLI
 
 class UninstallCommand: MintCommand {
 
-    var package = Parameter()
+    @Param var package: String
 
     init(mint: Mint) {
         super.init(mint: mint, name: "uninstall", description: "Uninstall a package by name")
@@ -12,7 +12,6 @@ class UninstallCommand: MintCommand {
 
     override func execute() throws {
         try super.execute()
-        let package = self.package.value
         try mint.uninstall(name: package)
     }
 }


### PR DESCRIPTION
This uses the new property wrappers introduced in SwiftCLI 6.0
```swift
@Flag("-s", "--silent", description: "Silences any output from Mint itself")
var silent: Bool
```