### PR TITLE
Allow mint run to drop the executable name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 #### Added
 - Added `--no-install` option to `mint run` [#160](https://github.com/yonaskolb/Mint/pull/160) @yonaskolb
 
-### Changed
+#### Changed
 - Moved output of some commands to `--verbose` and tweaked output [#154](https://github.com/yonaskolb/Mint/pull/154) @yonaskolb
+- The executable no longer needs to be provided in `mint run` when passing arguments if there is only a single executable in the package `mint run realm/SwiftLint autocorrect` [#159](https://github.com/yonaskolb/Mint/pull/159) @yonaskolb
 
 #### Internal
 - Updated to SwiftCLI 6.0 [#157](https://github.com/yonaskolb/Mint/pull/157) @yonaskolb

--- a/README.md
+++ b/README.md
@@ -96,12 +96,15 @@ Run `mint help` to see usage instructions.
 
 **Package reference**
 
-`run` and `install` commands require a package reference parameter. This can be a shorthand for a github repo (`mint install realm/SwiftLint`) or a fully qualified git path (`mint install https://github.com/realm/SwiftLint.git`). In the case of `run` you can also just pass the name of the repo if it is already installed (`run swiftlint`). This will do a lookup of all installed packages.
+`run` and `install` commands require a package reference parameter. This can be a shorthand for a github repo (`mint install realm/SwiftLint`) or a fully qualified git path (`mint install https://github.com/realm/SwiftLint.git`). In the case of `run` you can also just pass the name of the repo if it is already installed (`run swiftlint`) or in the Mintfile.
 An optional version can be specified by appending `@version`, otherwise the newest tag or master will be used. Note that if you don't specify a version, the current tags must be loaded remotely each time.
 
 #### Examples
 ```sh
-$ mint run yonaskolb/XcodeGen@1.2.4 xcodegen --spec spec.yml # pass some arguments
+$ mint run yonaskolb/XcodeGen@1.2.4 # run the only executable
+$ mint run yonaskolb/XcodeGen@1.2.4 --spec spec.yml # pass some arguments
+$ mint run yonaskolb/XcodeGen@1.2.4 xcodegen --spec spec.yml # specify a specific executable
+$ mint run --executable xcodegen yonaskolb/XcodeGen@1.2.4 --spec spec.yml # specify a specific executable in case the first argument is the same name as the executable
 $ mint install yonaskolb/XcodeGen@1.2.4 --no-link # installs a certain version but doesn't link it globally
 $ mint install yonaskolb/XcodeGen # install newest tag
 $ mint install yonaskolb/XcodeGen@master --force #reinstall the master branch

--- a/Sources/MintCLI/Commands/RunCommand.swift
+++ b/Sources/MintCLI/Commands/RunCommand.swift
@@ -5,6 +5,10 @@ import SwiftCLI
 class RunCommand: PackageCommand {
 
     @CollectedParam var arguments: [String]
+
+    @Key("-e", "--executable", description: "The executable to use")
+    var executable: String?
+
     @Flag("-n", "--no-install", description: "If a package is not already installed this prevents Mint from installing it automatically. It will fail instead")
     var noInstall: Bool
 
@@ -16,6 +20,6 @@ class RunCommand: PackageCommand {
     }
 
     override func execute(package: PackageReference) throws {
-        try mint.run(package: package, arguments: arguments, noInstall: noInstall)
+        try mint.run(package: package, arguments: arguments, executable: executable, noInstall: noInstall)
     }
 }

--- a/Tests/MintTests/MintTests.swift
+++ b/Tests/MintTests/MintTests.swift
@@ -180,8 +180,8 @@ class MintTests: XCTestCase {
             try mint.install(package: PackageReference(repo: "http://invaliddomain.com/invalid", version: testVersion))
         }
 
-        expectError(MintError.invalidExecutable("invalidCommand")) {
-            try mint.run(package: PackageReference(repo: testRepo, version: testVersion), arguments: ["invalidCommand"])
+        expectError(MintError.invalidExecutable("invalidExecutable")) {
+            try mint.run(package: PackageReference(repo: testRepo, version: testVersion), arguments: [], executable: "invalidExecutable")
         }
 
         expectError(MintError.packageNotFound("invalidPackage")) {


### PR DESCRIPTION
Fixes #145

This allows `mint run` to drop the executable name. It still supports it if specified. With packages with multiple executables it can still be specified, or a new `--executable` argument can be used in case the first arguments passed to the executable matches the executable

All of these work
```
mint run realm/SwiftLint
mint run realm/SwiftLint autocorrect
mint run swiftlint
mint run swiftLint autocorrect
mint run swiftLint swiftlint autocorrect #for backwards compatability
mint run --executable swiftlint realm/SwiftLint autocorrect
```