### PR TITLE
Allow running offline without specified version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Master
 
+#### Added
+- Running offline without specified version [#164](https://github.com/yonaskolb/Mint/issues/164) [#166](https://github.com/yonaskolb/Mint/pull/166) @vknabel
+
 ## 0.14.2
 
 #### Changed

--- a/Sources/MintKit/Mint.swift
+++ b/Sources/MintKit/Mint.swift
@@ -180,7 +180,7 @@ public class Mint {
                 guard let installedVersions = cache.packages
                         .first(where: { $0.gitRepo == package.repo })?
                         .versionDirs.map({ $0.version }),
-                    let fallbackVersion = installedVersions.first else {
+                    let fallbackVersion = installedVersions.last else {
                     throw MintError.repoNotFound(package.gitPath)
                 }
                 package.version = installedVersions

--- a/Sources/MintKit/Mint.swift
+++ b/Sources/MintKit/Mint.swift
@@ -173,8 +173,13 @@ public class Mint {
                     }
                 }
             } catch {
-                let repoVersionsPath = packagesPath + package.repoPath + "build"
-                guard let installedVersions = try? repoVersionsPath.children().map({ $0.lastComponent }),
+                let metadata = try readMetadata()
+                let linkedExecutables = getLinkedExecutables()
+                let cache = try Cache(path: packagesPath, metadata: metadata, linkedExecutables: linkedExecutables)
+                
+                guard let installedVersions = cache.packages
+                        .first(where: { $0.gitRepo == package.repo })?
+                        .versionDirs.map({ $0.version }),
                     let fallbackVersion = installedVersions.first else {
                     throw MintError.repoNotFound(package.gitPath)
                 }

--- a/Sources/MintKit/Mint.swift
+++ b/Sources/MintKit/Mint.swift
@@ -2,6 +2,7 @@ import Foundation
 import PathKit
 import Rainbow
 import SwiftCLI
+import Version
 
 public class Mint {
 
@@ -172,7 +173,15 @@ public class Mint {
                     }
                 }
             } catch {
-                throw MintError.repoNotFound(package.gitPath)
+                let repoVersionsPath = packagesPath + package.repoPath + "build"
+                guard let installedVersions = try? repoVersionsPath.children().map({ $0.lastComponent }),
+                    let fallbackVersion = installedVersions.first else {
+                    throw MintError.repoNotFound(package.gitPath)
+                }
+                package.version = installedVersions
+                    .compactMap(Version.init)
+                    .max()?.description ?? fallbackVersion
+                errorOutput( "Failed to find latest version online. Falling back to local version \(package.version)")
             }
             return true
         } else {


### PR DESCRIPTION
When the version cannot be resolved while being offline, this PR will try to find locally installed versions. It will try to use the latest version.
This fixes #164