### PR TITLE
Escape arguments for ls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master
 
+- Added escaping of paths when linking. Avoids an error, when MINT_LINK_PATH contains spaces. @lutzifer
+
 ## 0.14.1
 
 #### Fixed

--- a/Sources/MintKit/Mint.swift
+++ b/Sources/MintKit/Mint.swift
@@ -420,7 +420,7 @@ public class Mint {
         try? installPath.parent().mkpath()
 
         do {
-            try Task.run(bash: "ln -s \(packagePath.executablePath.string) \(installPath.string)")
+            try Task.run(bash: "ln -s \"\(packagePath.executablePath.string)\" \"\(installPath.string)\"")
         } catch {
             errorOutput("Could not link \(packagePath.commandVersion) to \(installPath.string)".red)
             return


### PR DESCRIPTION
I had issues, when MINT_LINK_PATH contained spaces.
Other similar calls seem to be escaped already.

Tested with the following scheme settings:
<img width="897" alt="Screenshot 2020-04-02 at 10 24 03" src="https://user-images.githubusercontent.com/194417/78226554-2ae4a780-74cc-11ea-9b8c-785af78f9f06.png">
