### PR TITLE
Added fixes to better support packages with multiple origins and multiple executables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - Added escaping of paths when linking. Avoids an error, when MINT_LINK_PATH contains spaces. @lutzifer
 
+#### Fixed
+- Rewrite the `list` option and fix the `run` option, to better support when a package with the same name is installed from different origins (for example: yonaskolb/xcodegen and acecilia/xcodegen). [#170](https://github.com/yonaskolb/Mint/pull/170) @acecilia
+- Rewrite the `list` option, to better support when a package produces multiple executables. [#170](https://github.com/yonaskolb/Mint/pull/170) @acecilia
+- Rewrite and fix the `uninstall` option: previously, the name for the symlink to remove was calculated using the package name passed from command line, which could be partial (for example `simple` instead of `simplepackage`), resulting on the symlink not being removed. [#170](https://github.com/yonaskolb/Mint/pull/170) @acecilia
+
 ## 0.14.1
 
 #### Fixed

--- a/Sources/MintKit/Cache.swift
+++ b/Sources/MintKit/Cache.swift
@@ -1,0 +1,96 @@
+import Foundation
+import PathKit
+
+/// A struct used as a representation of the cache
+struct Cache: Hashable {
+    struct PackageInfo: Hashable {
+        var name: String {
+            return PackageReference(repo: gitRepo).name
+        }
+        let gitRepo: String
+        let path: Path
+        let versionDirs: [VersionDir]
+    }
+
+    struct VersionDir: Hashable {
+        let path: Path
+        var version: String { path.lastComponent }
+        let executables: [ExecutableInfo]
+    }
+
+    struct ExecutableInfo: Hashable {
+        let path: Path
+        let linked: Bool
+        var name: String { path.lastComponent }
+    }
+
+    let packages: [PackageInfo]
+
+    init(path: Path, metadata: Mint.Metadata, linkedExecutables: [Path]) throws {
+        self.packages = try path.children()
+            .filter { $0.isDirectory && !$0.lastComponent.hasPrefix(".") }
+            .map { originPath in
+                let buildPath = originPath + "build"
+                let versionDirs: [VersionDir] = try buildPath.children()
+                    .filter { $0.isDirectory && !$0.lastComponent.hasPrefix(".") }
+                    .map { versionPath in
+                        let executables = try versionPath.children()
+                            .filter { $0.isFile && $0.extension == nil && !$0.lastComponent.hasPrefix(".") }
+                            .map { executablePath in
+                                ExecutableInfo(path: executablePath, linked: linkedExecutables.contains(executablePath))
+                            }
+                            .sorted { $0.name < $1.name }
+                        return VersionDir(path: versionPath, executables: executables)
+                    }
+                .sorted { $0.version < $1.version }
+
+                let gitRepos = metadata.packages.filter { $0.value == originPath.lastComponent }.map { $0.key }
+                let gitRepo: String
+                switch gitRepos.count {
+                case 0:
+                    throw MintError.inconsistentCache("Inconsistent metadata: git repository not found for package at path '\(originPath)'")
+                case 1:
+                    gitRepo = gitRepos[0]
+                default:
+                    throw MintError.inconsistentCache("Inconsistent metadata: multiple git repositories found for package at path '\(originPath)'")
+                }
+
+                return PackageInfo(gitRepo: gitRepo, path: originPath, versionDirs: versionDirs)
+            }
+            .sorted { $0.name < $1.name }
+    }
+
+    var list: String {
+        var description: [String] = []
+        for package in packages {
+            var packageDescription = ["  \(package.name)"]
+            if packages.filter({ $0.name == package.name }).count > 1 {
+                packageDescription.append("(\(package.gitRepo))")
+            }
+            description.append(packageDescription.joined(separator: " "))
+
+            for versionDir in package.versionDirs {
+                var versionDescription: [String] = ["    - \(versionDir.version)"]
+                if versionDir.executables.count == 1 {
+                    let executable = versionDir.executables[0]
+                    if executable.name.lowercased() != package.name.lowercased() {
+                        versionDescription.append("(\(executable.name)")
+                    }
+                    if executable.linked {
+                        versionDescription.append("*")
+                    }
+                } else if versionDir.executables.allSatisfy({ $0.linked }) {
+                    let executablesDescription = versionDir.executables.map { $0.name }.joined(separator: ", ")
+                    versionDescription.append("(\(executablesDescription)) *")
+                } else {
+                    let executablesDescription = versionDir.executables
+                        .map { $0.linked ? "\($0.name) *" : $0.name }
+                        .joined(separator: ", ")
+                    versionDescription.append("(\(executablesDescription))")
+                }
+                description.append(versionDescription.joined(separator: " "))
+            }
+        }
+        return description.joined(separator: "\n")
+    }
+}

--- a/Sources/MintKit/MintError.swift
+++ b/Sources/MintKit/MintError.swift
@@ -12,6 +12,7 @@ public enum MintError: Error, CustomStringConvertible, Equatable, LocalizedError
     case packageBuildError(PackageReference)
     case packageReadError(String)
     case packageNotInstalled(PackageReference)
+    case inconsistentCache(String)
 
     public var description: String {
         switch self {
@@ -25,6 +26,7 @@ public enum MintError: Error, CustomStringConvertible, Equatable, LocalizedError
         case let .packageBuildError(package): return "Failed to build \(package.namedVersion) with SPM"
         case let .packageReadError(error): return "Failed to read Package.swift file:\n\(error)"
         case let .packageNotInstalled(package): return "\(package.namedVersion) not installed"
+        case let .inconsistentCache(error): return "Inconsistent cache, clear it up.\nError: \(error)"
         }
     }
 

--- a/Tests/Fixtures/ComplexMintfile
+++ b/Tests/Fixtures/ComplexMintfile
@@ -1,0 +1,3 @@
+yonaskolb/SimplePackage@4.0.0
+acecilia/SimplePackage@6.0.0
+acecilia/SimplePackage@5.0.0

--- a/Tests/MintTests/Fixtures.swift
+++ b/Tests/MintTests/Fixtures.swift
@@ -3,3 +3,4 @@ import PathKit
 
 let mintFileFixture = Path(#file) + "../../Fixtures/Mintfile"
 let simpleMintFileFixture = Path(#file) + "../../Fixtures/SimpleMintfile"
+let complexMintFileFixture = Path(#file) + "../../Fixtures/ComplexMintfile"


### PR DESCRIPTION
Added fixes to cover the following two scenarios:
1- When a package with the same name is installed from different origins. For example: `yonaskolb/xcodegen` and `acecilia/xcodegen`.
2- When a package produces multiple executables.

The main additions of this PR are:
  1. A rewrite of the `list` option.
  2. A fix for the `run` option, so it asks for which package to run when multiple origins are detected, instead of just running the first match.
  3. A rewrite of the `uninstall` option, which includes the following fix: previously, the name for the symlink to remove was calculated using the passed package name, which could be partial (for example `sample` instead of `samplepackage`), resulting on the symlink not being removed. Also added tests