### PR TITLE
Added support for installing gems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Added escaping of paths when linking. Avoids an error, when MINT_LINK_PATH contains spaces. @lutzifer
 
+#### Added
+- Added support for installing gems. [#171](https://github.com/yonaskolb/Mint/pull/171) @acecilia
+
 ## 0.14.1
 
 #### Fixed

--- a/Sources/MintKit/MintError.swift
+++ b/Sources/MintKit/MintError.swift
@@ -9,9 +9,10 @@ public enum MintError: Error, CustomStringConvertible, Equatable, LocalizedError
     case cloneError(PackageReference)
     case mintfileNotFound(String)
     case packageResolveError(PackageReference)
-    case packageBuildError(PackageReference)
+    case packageBuildError(PackageReference, PackageType)
     case packageReadError(String)
     case packageNotInstalled(PackageReference)
+    case repoNotSupported(String)
 
     public var description: String {
         switch self {
@@ -22,9 +23,10 @@ public enum MintError: Error, CustomStringConvertible, Equatable, LocalizedError
         case let .invalidExecutable(executable): return "Couldn't find executable \(executable.quoted)"
         case let .missingExecutable(package): return "Executable product not found in \(package.namedVersion)"
         case let .packageResolveError(package): return "Failed to resolve \(package.namedVersion) with SPM"
-        case let .packageBuildError(package): return "Failed to build \(package.namedVersion) with SPM"
+        case let .packageBuildError(package, type): return "Failed to build \(package.namedVersion) with \(type.packageManager)"
         case let .packageReadError(error): return "Failed to read Package.swift file:\n\(error)"
         case let .packageNotInstalled(package): return "\(package.namedVersion) not installed"
+        case let .repoNotSupported(repo): return "Repository '\(repo)' does not contain a supported package. Supported package types: \(PackageType.allCases.map { $0.rawValue }.joined(separator: " ,"))"
         }
     }
 

--- a/Sources/MintKit/SupportedPackage.swift
+++ b/Sources/MintKit/SupportedPackage.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+public enum PackageType: String, CaseIterable {
+    case swift
+    case gem
+
+    public var packageManager: String {
+        switch self {
+        case .gem:
+            return "gem"
+
+        case .swift:
+            return "SPM"
+        }
+    }
+}

--- a/Tests/Fixtures/MintfileWithGems
+++ b/Tests/Fixtures/MintfileWithGems
@@ -1,0 +1,2 @@
+yonaskolb/SimplePackage@4.0.0
+xcpretty/xcpretty@v0.3.0

--- a/Tests/MintTests/Fixtures.swift
+++ b/Tests/MintTests/Fixtures.swift
@@ -3,3 +3,4 @@ import PathKit
 
 let mintFileFixture = Path(#file) + "../../Fixtures/Mintfile"
 let simpleMintFileFixture = Path(#file) + "../../Fixtures/SimpleMintfile"
+let mintfileWithGems = Path(#file) + "../../Fixtures/MintfileWithGems"


### PR DESCRIPTION
I recently had one of those days in which after countless hours fighting `gems`, `bundle 2.0.0`, `global gems`, `vendored gems`, `gemfile`, `gemfile.lock`, `RVM`, `rbenv`, `binstubs`, `ruby versions`, the CI server... I gave up. 
I just wanted a a way to specify a group of gems with a fixed version, and install them in a globally accessible location of my machine or the CI server, without the need of prefixing their invocation with `bundle exec`! How complex can it be... 🤦‍♀️
At some point in the middle of my frustration I came up with the idea that maybe `Mint` is able to install binary gems, same way it installs swift command line tools.

It may be a bit mind cracking that Mint, the swift package manager, supports installing gems. But if you think about it:

* Mint relies on the system installed tools (`swift`) to build the packages. Same way, it may rely on `gem` for installing gems.
* Multiple command line tools for iOS development are written in ruby and packed as gems.
* The alternative solutions (`bundle`) do not provide a simple way of installing a group of gems globally (if the `binstubs` were a hacky but possible way to do it, [seems like they will be gone in upcoming versions](https://github.com/rubygems/bundler/blob/master/UPGRADING.md)).
* So far, from what I have tested this works very well: installing gems is as straightforward as installing swift packages.