### PR TITLE
Fix installing git SHA version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 ## Master
 
-- Added escaping of paths when linking. Avoids an error, when MINT_LINK_PATH contains spaces. @lutzifer
-
 #### Fixed
 - Rewrite the `list` option and fix the `run` option, to better support when a package with the same name is installed from different origins (for example: yonaskolb/xcodegen and acecilia/xcodegen). [#170](https://github.com/yonaskolb/Mint/pull/170) @acecilia
 - Rewrite the `list` option, to better support when a package produces multiple executables. [#170](https://github.com/yonaskolb/Mint/pull/170) @acecilia
 - Rewrite and fix the `uninstall` option: previously, the name for the symlink to remove was calculated using the package name passed from command line, which could be partial (for example `simple` instead of `simplepackage`), resulting on the symlink not being removed. [#170](https://github.com/yonaskolb/Mint/pull/170) @acecilia
+- Fixed installing versions that reference a git sha [#172](https://github.com/yonaskolb/Mint/pull/172) @yonaskolb
+- Added escaping of paths when linking. Avoids an error, when MINT_LINK_PATH contains spaces. @lutzifer
+
 
 ## 0.14.1
 

--- a/Sources/MintKit/Mint.swift
+++ b/Sources/MintKit/Mint.swift
@@ -288,7 +288,14 @@ public class Mint {
 
         try? packageCheckoutPath.delete()
 
-        let cloneCommand = "git clone --depth 1 -b \(package.version) \(package.gitPath) \(package.repoPath)"
+        let cloneCommand: String
+        
+        if package.versionCouldBeSHA {
+            // version is maybe a SHA, so we can't do a shallow clone
+            cloneCommand = "git clone \(package.gitPath) \(package.repoPath) && cd \(package.repoPath) && git checkout \(package.version)"
+        } else {
+            cloneCommand = "git clone --depth 1 -b \(package.version) \(package.gitPath) \(package.repoPath)"
+        }
         try runPackageCommand(name: "Cloning \(package.namedVersion)",
                               command: cloneCommand,
                               directory: checkoutPath,

--- a/Sources/MintKit/PackageReference.swift
+++ b/Sources/MintKit/PackageReference.swift
@@ -61,6 +61,19 @@ public class PackageReference {
         }
     }
 
+    public var versionCouldBeSHA: Bool {
+        switch version {
+        case "master", "develop":
+            return false
+        default:
+            let characterSet = CharacterSet.letters.union(.decimalDigits)
+            if version.rangeOfCharacter(from: characterSet.inverted) != nil {
+                return false
+            }
+            return true
+        }
+    }
+
     var repoPath: String {
         return gitPath
             .components(separatedBy: "://").last!

--- a/Tests/MintTests/MintTests.swift
+++ b/Tests/MintTests/MintTests.swift
@@ -87,6 +87,12 @@ class MintTests: XCTestCase {
         XCTAssertTrue(try mint.listPackages().isEmpty)
     }
 
+    func testShaInstall() throws {
+        // install SHA version
+        let specificPackage = PackageReference(repo: testRepo, version: "c3cf95c")
+        try mint.install(package: specificPackage)
+    }
+
     func testRunCommand() throws {
 
         // run a specific version

--- a/Tests/MintTests/PackageTests.swift
+++ b/Tests/MintTests/PackageTests.swift
@@ -87,4 +87,18 @@ class PackageTests: XCTestCase {
         XCTAssertEqual(PackageReference(package: "ssh://git@server.com/user/project.git"), PackageReference(repo: "ssh://git@server.com/user/project.git"))
         XCTAssertEqual(PackageReference(package: "ssh://git@server.com/user/project.git@0.1"), PackageReference(repo: "ssh://git@server.com/user/project.git", version: "0.1"))
     }
+
+    func testPackageVersions() {
+
+        XCTAssertFalse(PackageReference.init(repo: "", version: "my_branch").versionCouldBeSHA)
+        XCTAssertFalse(PackageReference.init(repo: "", version: "develop").versionCouldBeSHA)
+        XCTAssertFalse(PackageReference.init(repo: "", version: "master").versionCouldBeSHA)
+        XCTAssertFalse(PackageReference.init(repo: "", version: "1.0").versionCouldBeSHA)
+        XCTAssertFalse(PackageReference.init(repo: "", version: "fgvb45g_").versionCouldBeSHA)
+        XCTAssertFalse(PackageReference.init(repo: "", version: "fgv/b45g").versionCouldBeSHA)
+        XCTAssertFalse(PackageReference.init(repo: "", version: "fgv.b45g").versionCouldBeSHA)
+
+        XCTAssertTrue(PackageReference.init(repo: "", version: "fgvb45g").versionCouldBeSHA)
+        XCTAssertTrue(PackageReference.init(repo: "", version: "fgvb45g6g4fgvb45g6g4fgvb45g6g4fgvb45g6g4").versionCouldBeSHA)
+    }
 }


### PR DESCRIPTION
Previously it was impossible to reference a git SHA because Mint used a shallow clone which doesn't support sha's. This detects such situations and then does a clone and checkout