### PR TITLE
Fix error on trying to install package with name only

### DIFF
--- a/Sources/MintKit/Mint.swift
+++ b/Sources/MintKit/Mint.swift
@@ -120,14 +120,16 @@ public class Mint {
     @discardableResult
     func resolvePackage(_ package: PackageReference) throws -> Bool {
 
-        // resolve version from MintFile
-        if package.version.isEmpty,
-            mintFilePath.exists,
-            let mintfile = try? Mintfile(path: mintFilePath) {
-            // set version to version from mintfile
-            if let mintFilePackage = mintfile.package(for: package.repo), !mintFilePackage.version.isEmpty {
+        // resolve repo and version from MintFile
+        if mintFilePath.exists,
+            let mintfile = try? Mintfile(path: mintFilePath),
+            let mintFilePackage = mintfile.package(for: package.repo) {
+            // set repo to repo from mintfile
+            package.repo = mintFilePackage.repo
+
+            if package.version.isEmpty, !mintFilePackage.version.isEmpty {
+                // set version to version from mintfile
                 package.version = mintFilePackage.version
-                package.repo = mintFilePackage.repo
                 if verbose {
                     output("Using \(package.repo) \(package.version) from Mintfile.")
                 }

--- a/Tests/Fixtures/MintfileWithoutVersion
+++ b/Tests/Fixtures/MintfileWithoutVersion
@@ -1,0 +1,1 @@
+yonaskolb/SimplePackage

--- a/Tests/MintTests/Fixtures.swift
+++ b/Tests/MintTests/Fixtures.swift
@@ -4,3 +4,4 @@ import PathKit
 let mintFileFixture = Path(#file) + "../../Fixtures/Mintfile"
 let simpleMintFileFixture = Path(#file) + "../../Fixtures/SimpleMintfile"
 let complexMintFileFixture = Path(#file) + "../../Fixtures/ComplexMintfile"
+let mintFileWithoutVersionFixture = Path(#file) + "../../Fixtures/MintfileWithoutVersion"

--- a/Tests/MintTests/MintTests.swift
+++ b/Tests/MintTests/MintTests.swift
@@ -193,6 +193,24 @@ class MintTests: XCTestCase {
         try checkInstalledVersion(package: specificPackage, executable: testCommand)
     }
 
+    func testMintFileWithoutVersionInstall() throws {
+        mint.mintFilePath = mintFileWithoutVersionFixture.absolute()
+
+        let specificPackage = PackageReference(repo: testRepoName)
+        try mint.install(package: specificPackage)
+        XCTAssertEqual(specificPackage.version, latestVersion)
+        try checkInstalledVersion(package: specificPackage, executable: testCommand)
+     }
+
+    func testMintFileWithoutVersionRun() throws {
+        mint.mintFilePath = mintFileWithoutVersionFixture.absolute()
+
+        let specificPackage = PackageReference(repo: testRepoName)
+        try mint.run(package: specificPackage)
+        XCTAssertEqual(specificPackage.version, latestVersion)
+        try checkInstalledVersion(package: specificPackage, executable: testCommand)
+     }
+
     func testMintErrors() {
 
         expectError(MintError.cloneError(PackageReference(repo: "http://invaliddomain.com/invalid", version: testVersion))) {


### PR DESCRIPTION
When Mintfile does not contain package versions, installing with simple
names such as `mint install xcodegen` fails with "package not found" error.

I'm not sure if Mintfile supports package specification without version though.