### PR TITLE
Support building for architectures other than x86_64 on macOS (Apple Silicon)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 #### Added
 - Running offline without specified version [#164](https://github.com/yonaskolb/Mint/issues/164) [#166](https://github.com/yonaskolb/Mint/pull/166) @vknabel
 
+#### Fixed
+- Support building for architectures other than x86_64 on macOS (Apple Silicon) [#185](https://github.com/yonaskolb/Mint/pull/185)
+
 ## 0.14.2
 
 #### Changed

--- a/Sources/MintKit/Mint.swift
+++ b/Sources/MintKit/Mint.swift
@@ -329,9 +329,12 @@ public class Mint {
 
         var buildCommand = "swift build -c release"
         #if os(macOS)
-            let osVersion = ProcessInfo.processInfo.operatingSystemVersion
-            let target = "x86_64-apple-macosx\(osVersion.majorVersion).\(osVersion.minorVersion)"
-            buildCommand += " -Xswiftc -target -Xswiftc \(target)"
+            let processInfo = ProcessInfo.processInfo
+            if let machineHardwareName = processInfo.machineHardwareName {
+                let osVersion = ProcessInfo.processInfo.operatingSystemVersion
+                let target = "\(machineHardwareName)-apple-macosx\(osVersion.majorVersion).\(osVersion.minorVersion)"
+                buildCommand += " -Xswiftc -target -Xswiftc \(target)"
+            }
         #endif
 
         try runPackageCommand(name: "Building package",

--- a/Sources/MintKit/ProcessInfoExtensions.swift
+++ b/Sources/MintKit/ProcessInfoExtensions.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+extension ProcessInfo {
+    /// Returns a `String` representing the machine hardware name or nil if there was an error invoking `uname(_:)` or decoding the response.
+    ///
+    /// Return value is the equivalent to running `$ uname -m` in shell.
+    var machineHardwareName: String? {
+        var sysinfo = utsname()
+        let result = uname(&sysinfo)
+        guard result == EXIT_SUCCESS else { return nil }
+
+        let data = Data(bytes: &sysinfo.machine, count: Int(_SYS_NAMELEN))
+
+        guard let identifier = String(bytes: data, encoding: .ascii) else { return nil }
+        return identifier.trimmingCharacters(in: .controlCharacters)
+    }
+}

--- a/Tests/MintTests/ProcessInfoExtensionTests.swift
+++ b/Tests/MintTests/ProcessInfoExtensionTests.swift
@@ -2,19 +2,15 @@
 import XCTest
 
 final class ProcessInfoExtensionTests: XCTestCase {
+    #if arch(x86_64)
     func testMachineHardwareName_Intel() {
-        #if !(os(macOS) && arch(x86_64))
-            print("Test can only be run on an Intel based Mac")
-        #else
-            XCTAssertEqual(ProcessInfo.processInfo.machineHardwareName, "x86_64")
-        #endif
+        XCTAssertEqual(ProcessInfo.processInfo.machineHardwareName, "x86_64")
     }
+    #endif
 
+    #if arch(arm64)
     func testMachineHardwareName_AppleSilicone() {
-        #if !(os(macOS) && arch(arm64))
-            print("Test can only be run on an Apple Silicon based Mac")
-        #else
-            XCTAssertEqual(ProcessInfo.processInfo.machineHardwareName, "arm64")
-        #endif
+        XCTAssertEqual(ProcessInfo.processInfo.machineHardwareName, "arm64")
     }
+    #endif
 }

--- a/Tests/MintTests/ProcessInfoExtensionTests.swift
+++ b/Tests/MintTests/ProcessInfoExtensionTests.swift
@@ -2,19 +2,19 @@
 import XCTest
 
 final class ProcessInfoExtensionTests: XCTestCase {
-    func testMachineHardwareName_Intel() throws {
+    func testMachineHardwareName_Intel() {
         #if !(os(macOS) && arch(x86_64))
-            try XCTSkipIf(true, "Not running tests on Intel based Mac")
+            print("Test can only be run on an Intel based Mac")
+        #else
+            XCTAssertEqual(ProcessInfo.processInfo.machineHardwareName, "x86_64")
         #endif
-
-        XCTAssertEqual(ProcessInfo.processInfo.machineHardwareName, "x86_64")
     }
 
-    func testMachineHardwareName_AppleSilicone() throws {
+    func testMachineHardwareName_AppleSilicone() {
         #if !(os(macOS) && arch(arm64))
-        try XCTSkipIf(true, "Not running tests on Apple Silicone based Mac")
+            print("Test can only be run on an Apple Silicon based Mac")
+        #else
+            XCTAssertEqual(ProcessInfo.processInfo.machineHardwareName, "arm64")
         #endif
-
-        XCTAssertEqual(ProcessInfo.processInfo.machineHardwareName, "arm64")
     }
 }

--- a/Tests/MintTests/ProcessInfoExtensionTests.swift
+++ b/Tests/MintTests/ProcessInfoExtensionTests.swift
@@ -1,0 +1,20 @@
+@testable import MintKit
+import XCTest
+
+final class ProcessInfoExtensionTests: XCTestCase {
+    func testMachineHardwareName_Intel() throws {
+        #if !(os(macOS) && arch(x86_64))
+            try XCTSkipIf(true, "Not running tests on Intel based Mac")
+        #endif
+
+        XCTAssertEqual(ProcessInfo.processInfo.machineHardwareName, "x86_64")
+    }
+
+    func testMachineHardwareName_AppleSilicone() throws {
+        #if !(os(macOS) && arch(arm64))
+        try XCTSkipIf(true, "Not running tests on Apple Silicone based Mac")
+        #endif
+
+        XCTAssertEqual(ProcessInfo.processInfo.machineHardwareName, "arm64")
+    }
+}


### PR DESCRIPTION
Closes #184 (cc @amine2233)

As identified in the linked PR, hardcoding the target when forming the `swift build` command on macOS has become a limiting factor when supporting Apple Silicon. Thankfully @esteluk already provided a viable work around that preserves some other requirements defined in #58.

I've taken the two suggestions and formed them into a single PR that should hopefully be good to go 🤞

I can confirm that this does the job nicely on Apple Silicon by using Realm's SwiftLint as a test project since your SimplePackage is too simple to throw up any build error in the tests. If it helps I can try and help you to expand that package a bit to reproduce the issue but I'm not sure how important that is.