### PR TITLE
Add overwrite option to mint install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Master
 
+#### Added
+- Added `--overwrite` option to `mint install` [#186](https://github.com/yonaskolb/Mint/pull/186) @Econa77
+
 ## 0.15.0
 
 #### Added

--- a/Sources/MintCLI/Commands/InstallCommand.swift
+++ b/Sources/MintCLI/Commands/InstallCommand.swift
@@ -12,6 +12,9 @@ class InstallCommand: PackageCommand {
     @Flag("-f", "--force", description: "Force a reinstall even if the package is already installed")
     var force: Bool
 
+    @Flag("-o", "--overwrite", description: "Force overwriting a package even if it is already installed globally")
+    var overwrite: Bool
+
     init(mint: Mint) {
         super.init(mint: mint,
                    name: "install",
@@ -21,6 +24,6 @@ class InstallCommand: PackageCommand {
 
     override func execute(package: PackageReference) throws {
         let link = !noLink
-        try mint.install(package: package, executable: executable, force: force, link: link)
+        try mint.install(package: package, executable: executable, force: force, link: link, overwrite: overwrite)
     }
 }

--- a/Sources/MintCLI/Commands/InstallCommand.swift
+++ b/Sources/MintCLI/Commands/InstallCommand.swift
@@ -12,7 +12,7 @@ class InstallCommand: PackageCommand {
     @Flag("-f", "--force", description: "Force a reinstall even if the package is already installed")
     var force: Bool
 
-    @Key("-o", "--overwrite", description: "Overwrite a symlinked executable that is not installed by mint. Either (y/n)")
+    @Key("-o", "--overwrite", description: "Automatically overwrite a symlinked executable that is not installed by mint without asking. Either (y/n)")
     var overwrite: Bool?
 
     init(mint: Mint) {

--- a/Sources/MintCLI/Commands/InstallCommand.swift
+++ b/Sources/MintCLI/Commands/InstallCommand.swift
@@ -12,8 +12,8 @@ class InstallCommand: PackageCommand {
     @Flag("-f", "--force", description: "Force a reinstall even if the package is already installed")
     var force: Bool
 
-    @Flag("-o", "--overwrite", description: "Force overwriting a package even if it is already installed globally")
-    var overwrite: Bool
+    @Key("-o", "--overwrite", description: "Overwrite a symlinked executable that is not installed by mint. Either (y/n)")
+    var overwrite: Bool?
 
     init(mint: Mint) {
         super.init(mint: mint,

--- a/Sources/MintKit/Mint.swift
+++ b/Sources/MintKit/Mint.swift
@@ -268,7 +268,7 @@ public class Mint {
 
     @discardableResult
     /// returns if the package was installed
-    public func install(package: PackageReference, executable: String? = nil, beforeOtherCommand: Bool = false, force: Bool = false, link: Bool = false, noInstall: Bool = false, overwrite: Bool = false) throws -> Bool {
+    public func install(package: PackageReference, executable: String? = nil, beforeOtherCommand: Bool = false, force: Bool = false, link: Bool = false, noInstall: Bool = false, overwrite: Bool? = nil) throws -> Bool {
 
         try resolvePackage(package)
 
@@ -425,17 +425,22 @@ public class Mint {
         }
     }
 
-    func linkPackage(_ package: PackageReference, executable: String, overwrite: Bool) throws {
+    func linkPackage(_ package: PackageReference, executable: String, overwrite: Bool?) throws {
 
         let packagePath = PackagePath(path: packagesPath, package: package, executable: executable)
         let installPath = linkPath + packagePath.executable!
 
         let installStatus = try InstallStatus(path: installPath, mintPackagesPath: packagesPath)
 
-        if let warning = installStatus.warning, !overwrite {
-            let ok = Input.confirmation("🌱  \(warning)\nOverwrite it with Mint's symlink?".yellow)
-            if !ok {
+        if let warning = installStatus.warning {
+            if let overwrite = overwrite, !overwrite {
                 return
+            }
+            if overwrite == nil {
+                let ok = Input.confirmation("🌱  \(warning)\nOverwrite it with Mint's symlink?".yellow)
+                if !ok {
+                    return
+                }
             }
         }
 

--- a/Sources/MintKit/Mint.swift
+++ b/Sources/MintKit/Mint.swift
@@ -268,7 +268,7 @@ public class Mint {
 
     @discardableResult
     /// returns if the package was installed
-    public func install(package: PackageReference, executable: String? = nil, beforeOtherCommand: Bool = false, force: Bool = false, link: Bool = false, noInstall: Bool = false) throws -> Bool {
+    public func install(package: PackageReference, executable: String? = nil, beforeOtherCommand: Bool = false, force: Bool = false, link: Bool = false, noInstall: Bool = false, overwrite: Bool = false) throws -> Bool {
 
         try resolvePackage(package)
 
@@ -286,11 +286,11 @@ public class Mint {
             }
             if link {
                 if let executable = executable {
-                    try linkPackage(package, executable: executable)
+                    try linkPackage(package, executable: executable, overwrite: overwrite)
                 } else {
                     let executables = try packagePath.getExecutables()
                     for executable in executables {
-                        try linkPackage(package, executable: executable)
+                        try linkPackage(package, executable: executable, overwrite: overwrite)
                     }
                 }
             }
@@ -388,10 +388,10 @@ public class Mint {
 
         if link {
             if let executable = executable {
-                try linkPackage(package, executable: executable)
+                try linkPackage(package, executable: executable, overwrite: overwrite)
             } else {
                 for executable in executables {
-                    try linkPackage(package, executable: executable)
+                    try linkPackage(package, executable: executable, overwrite: overwrite)
                 }
             }
         }
@@ -425,14 +425,14 @@ public class Mint {
         }
     }
 
-    func linkPackage(_ package: PackageReference, executable: String) throws {
+    func linkPackage(_ package: PackageReference, executable: String, overwrite: Bool) throws {
 
         let packagePath = PackagePath(path: packagesPath, package: package, executable: executable)
         let installPath = linkPath + packagePath.executable!
 
         let installStatus = try InstallStatus(path: installPath, mintPackagesPath: packagesPath)
 
-        if let warning = installStatus.warning {
+        if let warning = installStatus.warning, !overwrite {
             let ok = Input.confirmation("🌱  \(warning)\nOverwrite it with Mint's symlink?".yellow)
             if !ok {
                 return


### PR DESCRIPTION
When installing globally, you must enter whether you want to overwrite the package if it is already installed. I added an option to override when using it in CI, as in #182 

I'd like to add a similar option to the `mint bootstrap` command afterwards, if this change is approved.