### PR TITLE
Build universal binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ install: build
 	cp -f $(BUILD_PATH) $(INSTALL_PATH)
 
 build:
-	swift build --disable-sandbox -c release
+	swift build --disable-sandbox -c release --arch arm64 --arch x86_64
 
 uninstall:
 	rm -f $(INSTALL_PATH)


### PR DESCRIPTION
Build a universal binary to include arm64 as mentioned in #185 as per https://liamnichols.github.io/2020/08/01/building-swift-packages-as-a-universal-binary.html