### PR TITLE
Skip Apple Silicon supporting flow on Linux platform.

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -5,7 +5,7 @@ on:
   pull_request: {}
 
 jobs:
-  build:
+  macOS:
     runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v2
@@ -15,3 +15,14 @@ jobs:
       run: swift build
     - name: Run tests
       run: swift test 2>&1 | xcpretty
+  linux:
+    runs-on: ubuntu-latest
+    container: swift:5.2
+    steps:
+      - uses: actions/checkout@v2
+      - name: Resolve
+        run: swift package resolve
+      - name: Build
+        run: swift build
+      - name: Run tests
+        run: swift test 2>&1

--- a/Sources/MintKit/ProcessInfoExtensions.swift
+++ b/Sources/MintKit/ProcessInfoExtensions.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 extension ProcessInfo {
+    #if os(macOS)
     /// Returns a `String` representing the machine hardware name or nil if there was an error invoking `uname(_:)` or decoding the response.
     ///
     /// Return value is the equivalent to running `$ uname -m` in shell.
@@ -14,4 +15,5 @@ extension ProcessInfo {
         guard let identifier = String(bytes: data, encoding: .ascii) else { return nil }
         return identifier.trimmingCharacters(in: .controlCharacters)
     }
+    #endif
 }

--- a/Tests/MintTests/ProcessInfoExtensionTests.swift
+++ b/Tests/MintTests/ProcessInfoExtensionTests.swift
@@ -2,6 +2,8 @@
 import XCTest
 
 final class ProcessInfoExtensionTests: XCTestCase {
+    #if os(macOS)
+
     #if arch(x86_64)
     func testMachineHardwareName_Intel() {
         XCTAssertEqual(ProcessInfo.processInfo.machineHardwareName, "x86_64")
@@ -12,5 +14,7 @@ final class ProcessInfoExtensionTests: XCTestCase {
     func testMachineHardwareName_AppleSilicone() {
         XCTAssertEqual(ProcessInfo.processInfo.machineHardwareName, "arm64")
     }
+    #endif
+
     #endif
 }


### PR DESCRIPTION
Resolves #196 

[`ProcessInfo.machineHardwareName`](https://github.com/yonaskolb/Mint/pull/185/files#diff-e90019304d64f8d341431032f67544626424aaa233785b85ba42667c4a69a61dR7) has caused a compile error on Linux platform.
However, it was not called on Linux platform, so I made it only available on macOS platform.

Furthermore, I added the test on Linux which has been missed in #158 .