### PR TITLE
Add support for `main` as the default branch

### DIFF
--- a/Sources/MintCLI/Commands/PackageCommand.swift
+++ b/Sources/MintCLI/Commands/PackageCommand.swift
@@ -15,7 +15,7 @@ class PackageCommand: MintfileCommand {
         \(description)
         
         The package can be a shorthand for a github repo \"githubName/repo\", or a fully qualified .git path.
-        An optional version can be specified by appending @version to the repo, otherwise the newest tag will be used (or master if no tags are found.)
+        An optional version can be specified by appending @version to the repo, otherwise the newest tag will be used (or main, then master if no tags are found.)
         """
         if let parameterDescription = parameterDescription {
             longDescription += "\n\n\(parameterDescription)"

--- a/Sources/MintKit/PackageReference.swift
+++ b/Sources/MintKit/PackageReference.swift
@@ -63,7 +63,7 @@ public class PackageReference {
 
     public var versionCouldBeSHA: Bool {
         switch version {
-        case "master", "develop":
+        case "main", "master", "develop":
             return false
         default:
             let characterSet = CharacterSet.letters.union(.decimalDigits)

--- a/Tests/MintTests/PackageTests.swift
+++ b/Tests/MintTests/PackageTests.swift
@@ -92,6 +92,7 @@ class PackageTests: XCTestCase {
 
         XCTAssertFalse(PackageReference(repo: "", version: "my_branch").versionCouldBeSHA)
         XCTAssertFalse(PackageReference(repo: "", version: "develop").versionCouldBeSHA)
+        XCTAssertFalse(PackageReference(repo: "", version: "main").versionCouldBeSHA)
         XCTAssertFalse(PackageReference(repo: "", version: "master").versionCouldBeSHA)
         XCTAssertFalse(PackageReference(repo: "", version: "1.0").versionCouldBeSHA)
         XCTAssertFalse(PackageReference(repo: "", version: "fgvb45g_").versionCouldBeSHA)


### PR DESCRIPTION
GitHub and others [are moving to use `main` as the default branch name](https://github.com/github/renaming). In fact newly created repositories use it by default now. The most recent version/commit of Mint fails to clone tools that don’t have any tags and uses `main`:

```shell
$ mint run rastersize/apollo-codegen
🌱 Finding latest version of apollo-codegen
🌱 Cloning apollo-codegen master
Cloning into 'github.com_rastersize_apollo-codegen'...
warning: Could not find remote branch master to clone.
fatal: Remote branch master not found in upstream origin
🌱 Encountered error during "git clone --depth 1 -b master https://github.com/rastersize/apollo-codegen.git github.com_rastersize_apollo-codegen". Use --verbose to see full output
🌱  Couldn't clone https://github.com/rastersize/apollo-codegen.git master
```

This PR aims to resolve that by adding support for both `main` and `master`. It should in theory support any name for the default branch as it uses `git` to look up the name of the branch.

With this patch the invocation above succeeds:

```shell
$ .build/debug/mint run rastersize/apollo-codegen apollo-codegen --help
🌱 Finding latest version of apollo-codegen
🌱 Cloning apollo-codegen main
🌱 Resolving package
🌱 Building package
🌱 Installed apollo-codegen main
🌱 Running apollo-codegen main...
OVERVIEW: A utility for performing Apollo GraphQL related tasks.

[...]
```