### PR TITLE
Change install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ $ mint run XcodeGen # use newest tag and find XcodeGen in installed packages
 ```
 
 ### Linking
-By default Mint symlinks your installs into `usr/local/bin` on `mint install`, unless `--no-link` is passed. This means a package will be accessible from anywhere, and you don't have to prepend commands with `mint run package`. Note that only one linked version can be used at a time though. If you need to run a specific older version use `mint run`.
+By default Mint symlinks your installs into `~/.mint/bin` on `mint install`, unless `--no-link` is passed. This means a package will be accessible from anywhere, and you don't have to prepend commands with `mint run package`, as long as you add `~/.mint/bin` to your `$PATH`. Note that only one linked version can be used at a time. If you need to run a specific older version use `mint run`.
 
 ### Mintfile
 A `Mintfile` can specify a list of versioned packages. It makes installing and running these packages easy, as the specific repos and versions are centralized.
@@ -146,7 +146,7 @@ mint bootstrap --link
 
 ### Advanced
 - You can use `--silent` in `mint run` to silence any output from mint itself. Useful if forwarding output somewhere else.
-- You can set `MINT_PATH` and `MINT_LINK_PATH` envs to configure where mint caches builds, and where it symlinks global installs. These default to `/usr/local/lib/mint` and `/usr/local/bin` respectively
+- You can set `MINT_PATH` and `MINT_LINK_PATH` envs to configure where mint caches builds, and where it symlinks global installs. These default to `~/.mint` and `~/.mint/bin` respectively
 - You can use `mint install --force` to reinstall a package even if it's already installed. This shouldn't be required unless you are pointing at a branch and want to update it.
 
 ### Linux

--- a/Sources/MintCLI/MintCLI.swift
+++ b/Sources/MintCLI/MintCLI.swift
@@ -13,8 +13,8 @@ public class MintCLI {
 
     public init() {
 
-        var mintPath: Path = "/usr/local/lib/mint"
-        var linkPath: Path = "/usr/local/bin"
+        var mintPath: Path = "~/.mint"
+        var linkPath: Path = "~/.mint/bin"
 
         if let path = ProcessInfo.processInfo.environment["MINT_PATH"], !path.isEmpty {
             mintPath = Path(path)

--- a/Sources/MintKit/Mint.swift
+++ b/Sources/MintKit/Mint.swift
@@ -293,6 +293,7 @@ public class Mint {
                         try linkPackage(package, executable: executable, overwrite: overwrite)
                     }
                 }
+                checkLinkPath()
             }
             return false
         }
@@ -394,9 +395,16 @@ public class Mint {
                     try linkPackage(package, executable: executable, overwrite: overwrite)
                 }
             }
+            checkLinkPath()
         }
 
         return true
+    }
+    
+    private func checkLinkPath() {
+        if let path = ProcessInfo.processInfo.environment["PATH"], !path.contains(linkPath.string) {
+            output("\(linkPath) must be added to your $PATH if you wish to run this package outside of mint".yellow)
+        }
     }
 
     private func runPackageCommand(name: String, command: String, directory: Path, stdOutOnError: Bool = false, error mintError: MintError) throws {


### PR DESCRIPTION
Fixes #188
Fixes #215

This changes `$MINT_PATH` to default to `~/.mint` which means there won't be installation issues on higher protected macOS releases or M1 machines.
It also changes `$MINT_LINK_PATH` to `~/.mint/bin` which means global linking will now also succeed with the downside that `~/.mint/bin` must manually be added to `$PATH` if packages need to be run outside of mint