### PR TITLE
Add note about how packages are resolved

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,11 +126,13 @@ yonaskolb/xcodegen@2.18.0
 yonaskolb/genesis@0.4.0
 ```
 
-Then you can simply run a package with:
+Then you can simply run a package using:
 
 ```sh
 mint run xcodegen
 ```
+
+Note that mint will find the version declared in your Mintfile and run that version, even if you have multiple versions installed.
 
 Or install all the packages (without linking them globally) in one go with:
 


### PR DESCRIPTION
In the main section it says that using `mint run` will run the latest version of a package which is installed. Then the Mintfile section says that you can use `mint run tool-name` which is the same as above and I was worried that it would run the latest version. (so I added note to clarify that the version would be resolved from the Mintfile)

We've got multiple projects over here and are using mint to install / manage package tools on our CI machines.