### PR TITLE
Add support for SPM resource bundles

### DIFF
--- a/Sources/MintKit/SwiftPackage.swift
+++ b/Sources/MintKit/SwiftPackage.swift
@@ -6,6 +6,7 @@ struct SwiftPackage: Decodable {
 
     let name: String
     let products: [Product]
+    let targets: [Target]
 
     init(directory: Path) throws {
 
@@ -34,11 +35,13 @@ struct SwiftPackage: Decodable {
 
         let name: String
         let isExecutable: Bool
+        let targetNames: [String]
 
         enum CodingKeys: String, CodingKey {
             case name
             case type
             case productType = "product_type"
+            case targets
         }
 
         init(from decoder: Decoder) throws {
@@ -59,6 +62,61 @@ struct SwiftPackage: Decodable {
                 let typeContainer = try container.nestedContainer(keyedBy: ProductCodingKeys.self, forKey: .type)
                 isExecutable = typeContainer.contains(.executable)
             }
+            targetNames = try container.decode([String].self, forKey: .targets)
+        }
+    }
+
+    struct Target: Decodable {
+
+        let name: String
+        let resources: [Resource]
+        let dependencies: [Dependency]
+
+        enum CodingKeys: String, CodingKey {
+            case name
+            case resources
+            case type
+            case dependencies
+        }
+
+        enum ResourceCodingKeys: String, CodingKey {
+            case path
+            case rule
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            name = try container.decode(String.self, forKey: .name)
+            resources = try container.decode([Resource].self, forKey: .resources)
+            dependencies = try container.decode([Dependency].self, forKey: .dependencies)
+        }
+    }
+
+    struct Resource: Decodable {
+
+        let path: String
+
+        enum CodingKeys: String, CodingKey {
+            case path
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            path = try container.decode(String.self, forKey: .path)
+        }
+    }
+
+    struct Dependency: Decodable {
+
+        let byName: [String]
+
+        enum CodingKeys: String, CodingKey {
+            case byName
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            byName = try container.decode([String?].self, forKey: .byName).compactMap { $0 }
         }
     }
 }


### PR DESCRIPTION
Added support for resouce in SPM version 5.3 or later. #223
SPM outputs a file named `[package name]_[target name].bundle` (or `*.resources` on linux) when `resources` is specified for a target in Package.swift. If `resources` is specified for multiple targets, multiple bundles will be output, so I had to figure out the dependency graph and copy only what I need.  
For example, SwiftGen outputs the following two bundles in the build, but mint should only copy one of them. (The other one is for testing, so it is not needed).

* SwiftGen_SwiftGenCLI.bundle
* SwiftGen_TestUtils.bundle

We also had to take into consider the case where resources are included in external packages that we depend on, so I separated the commits.

I used the following repository to test this.
* [SwiftGen/SwiftGen](https://github.com/SwiftGen/SwiftGen)
* [tid-kijyun/Sample](https://github.com/tid-kijyun/Sample) :My sample project, including resources

### About Unit Tests
I haven't written any unit tests because I didn't think I should use my personal repository for testing.
If you can prepare a sample repository of packages that contain some resources, we can write unit tests.