### PR TITLE
Add XCTestHTMLReport to package list

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,5 +215,6 @@ If this file is found in you repo, then all those directories will be copied int
 - mint install [ChargePoint/xcparse](https://github.com/ChargePoint/xcparse)
 - mint install [scribd/Weaver](https://github.com/scribd/Weaver)
 - mint install [arthurpalves/coherent-swift](https://github.com/arthurpalves/coherent-swift)
+- mint install [XCTestHTMLReport/XCTestHTMLReport](https://github.com/XCTestHTMLReport/XCTestHTMLReport)
 
 Feel free to add your own!


### PR DESCRIPTION
Hi! We've updated our README over at XCTestHTMLReport/XCTestHTMLReport to use Mint as the preferred install method. I've added our repo to the compatible package list here.