### PR TITLE
Avoid test utility module in some packages.

### DIFF
--- a/Sources/MintKit/Mint.swift
+++ b/Sources/MintKit/Mint.swift
@@ -331,6 +331,9 @@ public class Mint {
         }
 
         var buildCommand = "swift build -c release"
+        for executable in executables {
+            buildCommand += " --product \(executable)"
+        }
         #if os(macOS)
             let processInfo = ProcessInfo.processInfo
             if let machineHardwareName = processInfo.machineHardwareName {


### PR DESCRIPTION
Resolves #250 

I tried to run `mint install` with this fix and succeeded on SwiftLint, SwiftFormat and [SSGH(my original package)](https://github.com/417-72KI/SSGH).