### PR TITLE
Build executables one by one

### DIFF
--- a/Sources/MintKit/Mint.swift
+++ b/Sources/MintKit/Mint.swift
@@ -330,24 +330,24 @@ public class Mint {
             throw MintError.missingExecutable(package)
         }
 
-        var buildCommand = "swift build -c release"
         for executable in executables {
-            buildCommand += " --product \(executable)"
-        }
-        #if os(macOS)
-            let processInfo = ProcessInfo.processInfo
-            if let machineHardwareName = processInfo.machineHardwareName {
-                let osVersion = ProcessInfo.processInfo.operatingSystemVersion
-                let target = "\(machineHardwareName)-apple-macosx\(osVersion.majorVersion).\(osVersion.minorVersion)"
-                buildCommand += " -Xswiftc -target -Xswiftc \(target)"
-            }
-        #endif
+            var buildCommand = "swift build -c release --product \(executable)"
 
-        try runPackageCommand(name: "Building package",
-                              command: buildCommand,
-                              directory: packageCheckoutPath,
-                              stdOutOnError: true,
-                              error: .packageBuildError(package))
+            #if os(macOS)
+                let processInfo = ProcessInfo.processInfo
+                if let machineHardwareName = processInfo.machineHardwareName {
+                    let osVersion = ProcessInfo.processInfo.operatingSystemVersion
+                    let target = "\(machineHardwareName)-apple-macosx\(osVersion.majorVersion).\(osVersion.minorVersion)"
+                    buildCommand += " -Xswiftc -target -Xswiftc \(target)"
+                }
+            #endif
+
+            try runPackageCommand(name: "Building product \(executable)",
+                                  command: buildCommand,
+                                  directory: packageCheckoutPath,
+                                  stdOutOnError: true,
+                                  error: .packageBuildError(package))
+        }
 
         let packageBuildPath = packageCheckoutPath + ".build/release"
         let packageInstallPath = packagePath.installPath


### PR DESCRIPTION
closes #255

The changes in #251 add each executable target as an additional `--product \(executable)` to the `swift build` command. Unfortunately, when multiple products are specified with `--product \(executable)`, `swift build` does not build all of them, only the last one.

`swift build` does not seem to have a way to explicitly specify multiple products to build at once, so instead this PR makes Mint run `swift build` once for each executable product.