### PR TITLE
Symlink Resource Artifacts

### DIFF
--- a/Sources/MintKit/Mint.swift
+++ b/Sources/MintKit/Mint.swift
@@ -566,9 +566,11 @@ public class Mint {
         }
 
         // get resources across all installed versions
-        let resources = try package.versionDirs
-            .map { try getResources(from: $0.path) }
-            .flatMap { $0 }
+        let resources = Set(
+            try package.versionDirs
+                .map { try getResources(from: $0.path) }
+                .flatMap { $0 }
+        )
 
         try package.path.delete()
         output("\(package.name) was uninstalled")
@@ -586,10 +588,7 @@ public class Mint {
         // remove all resource artifact links
         for resource in resources {
             let installPath = linkPath + resource.lastComponent
-
-            /* `try?` to suppress error in console, which will
-            happen when same resource is deleted from multiple versions */
-            try? installPath.delete()
+            try installPath.delete()
         }
     }
 }

--- a/Sources/MintKit/Mint.swift
+++ b/Sources/MintKit/Mint.swift
@@ -293,6 +293,7 @@ public class Mint {
                         try linkPackage(package, executable: executable, overwrite: overwrite)
                     }
                 }
+                try linkResources(package)
                 checkLinkPath()
             }
             return false
@@ -390,6 +391,7 @@ public class Mint {
                     try linkPackage(package, executable: executable, overwrite: overwrite)
                 }
             }
+            try linkResources(package)
             checkLinkPath()
         }
 
@@ -406,12 +408,7 @@ public class Mint {
             pathsToCopy.append(executablePath)
         }
 
-        let copiedExtensions: Set = ["bundle", "resources", "dylib"]
-        for path in try buildPath.children() {
-            if let ext = path.extension, copiedExtensions.contains(ext) {
-                pathsToCopy.append(path)
-            }
-        }
+        try pathsToCopy.append(contentsOf: getResources(from: buildPath))
 
         for path in pathsToCopy {
             let destinationPath = installPath + path.lastComponent
@@ -420,6 +417,18 @@ public class Mint {
             }
             // copy using shell instead of FileManager via PathKit because it removes executable permissions on Linux
             try Task.run(bash: "cp -R \(path.string) \(destinationPath.string)")
+        }
+    }
+
+    private func getResources(from path: Path) throws -> [Path] {
+        let extensions: Set = ["bundle", "resources", "dylib"]
+
+        return try path.children().filter {
+            guard let ext = $0.extension, extensions.contains(ext) else {
+                return false
+            }
+
+            return true
         }
     }
     
@@ -489,6 +498,22 @@ public class Mint {
         }
 
         output(confirmation.green)
+    }
+
+    func linkResources(_ package: PackageReference) throws {
+        let packagePath = PackagePath(path: packagesPath, package: package)
+        let resources = try getResources(from: packagePath.installPath)
+
+        for resource in resources {
+            let installPath = linkPath + resource.lastComponent
+
+            do {
+                try Task.run(bash: "ln -s \"\(packagePath.installPath + resource.lastComponent)\" \"\(installPath.string)\"")
+            } catch {
+                errorOutput("Could not link \(resource.lastComponent) to \(installPath.string)".red)
+                return
+            }
+        }
     }
 
     public func bootstrap(link: Bool = false, overwrite: Bool? = nil) throws {

--- a/Sources/MintKit/Mint.swift
+++ b/Sources/MintKit/Mint.swift
@@ -564,6 +564,11 @@ public class Mint {
             let option = Input.readOption(options: packages.map { $0.gitRepo }, prompt: "There are multiple packages matching '\(name)', which one would you like to uninstall?")
             package = packages.first { $0.gitRepo == option }!
         }
+
+        let resources = try package.versionDirs
+            .map { try getResources(from: $0.path) }
+            .flatMap { $0 }
+
         try package.path.delete()
         output("\(package.name) was uninstalled")
 
@@ -574,6 +579,12 @@ public class Mint {
         // remove link
         for executable in Set(package.versionDirs.flatMap { $0.executables }) where executable.linked {
             let installPath = linkPath + executable.name
+            try installPath.delete()
+        }
+
+        // remove resource artifact link
+        for resource in resources {
+            let installPath = linkPath + resource.lastComponent
             try installPath.delete()
         }
     }

--- a/Sources/MintKit/Mint.swift
+++ b/Sources/MintKit/Mint.swift
@@ -508,7 +508,7 @@ public class Mint {
             let installPath = linkPath + resource.lastComponent
 
             do {
-                try Task.run(bash: "ln -s \"\(packagePath.installPath + resource.lastComponent)\" \"\(installPath.string)\"")
+                try Task.run(bash: "ln -s -f \"\(packagePath.installPath + resource.lastComponent)\" \"\(installPath.string)\"")
             } catch {
                 errorOutput("Could not link \(resource.lastComponent) to \(installPath.string)".red)
                 return

--- a/Sources/MintKit/Mint.swift
+++ b/Sources/MintKit/Mint.swift
@@ -565,6 +565,7 @@ public class Mint {
             package = packages.first { $0.gitRepo == option }!
         }
 
+        // get resources across all installed versions
         let resources = try package.versionDirs
             .map { try getResources(from: $0.path) }
             .flatMap { $0 }
@@ -582,10 +583,13 @@ public class Mint {
             try installPath.delete()
         }
 
-        // remove resource artifact link
+        // remove all resource artifact links
         for resource in resources {
             let installPath = linkPath + resource.lastComponent
-            try installPath.delete()
+
+            /* `try?` to suppress error in console, which will
+            happen when same resource is deleted from multiple versions */
+            try? installPath.delete()
         }
     }
 }

--- a/Sources/MintKit/Mint.swift
+++ b/Sources/MintKit/Mint.swift
@@ -508,7 +508,7 @@ public class Mint {
             let installPath = linkPath + resource.lastComponent
 
             do {
-                try Task.run(bash: "ln -s -f \"\(packagePath.installPath + resource.lastComponent)\" \"\(installPath.string)\"")
+                try Task.run(bash: "ln -s -f -h \"\(packagePath.installPath + resource.lastComponent)\" \"\(installPath.string)\"")
             } catch {
                 errorOutput("Could not link \(resource.lastComponent) to \(installPath.string)".red)
                 return


### PR DESCRIPTION
The PR seeks to address the issue outlined in #261. The issue being that resource artifacts such as bundles are not found, causing termination. 

I've implemented a naive solution which is to create symlinks for resource artifacts when a package is installed, as noted as a workaround in SwiftGen/SwiftGen#905. I'm also deleting the symlinks when packages are uninstalled.

I acknowledge there could be concern about namespace collisions, however I see this as an extreme edge case and the same collisions would exist with the executable target, unless I'm missing something. 

Please let me know if any improvements could be made to help get this merged.