### PR TITLE
Add quotes when copying result binary

### DIFF
--- a/Sources/MintKit/Mint.swift
+++ b/Sources/MintKit/Mint.swift
@@ -419,7 +419,7 @@ public class Mint {
                 standardOut.print("Copying \(path) to \(destinationPath)")
             }
             // copy using shell instead of FileManager via PathKit because it removes executable permissions on Linux
-            try Task.run(bash: "cp -R \(path.string) \(destinationPath.string)")
+            try Task.run(bash: "cp -R \"\(path.string)\" \"\(destinationPath.string)\"")
         }
     }
     


### PR DESCRIPTION
If user customized `MINT_PATH` and `MINT_LINK_PATH` to paths that contain spaces, the final copy of the binary failed because of missing quotes, this PR fixes that.