### PR TITLE
Git Submodule Support

### DIFF
--- a/Sources/MintKit/Mint.swift
+++ b/Sources/MintKit/Mint.swift
@@ -310,9 +310,9 @@ public class Mint {
 
         if package.versionCouldBeSHA {
             // version is maybe a SHA, so we can't do a shallow clone
-            cloneCommand = "git clone \(package.gitPath) \(package.repoPath) && cd \(package.repoPath) && git checkout \(package.version)"
+            cloneCommand = "git clone \(package.gitPath) \(package.repoPath) && cd \(package.repoPath) && git checkout --recurse-submodules \(package.version)"
         } else {
-            cloneCommand = "git clone --depth 1 -b \(package.version) \(package.gitPath) \(package.repoPath)"
+            cloneCommand = "git clone --depth 1 --recurse-submodules -b \(package.version) \(package.gitPath) \(package.repoPath)"
         }
         try runPackageCommand(name: "Cloning \(package.namedVersion)",
                               command: cloneCommand,

--- a/Sources/MintKit/Mint.swift
+++ b/Sources/MintKit/Mint.swift
@@ -310,7 +310,7 @@ public class Mint {
 
         if package.versionCouldBeSHA {
             // version is maybe a SHA, so we can't do a shallow clone
-            cloneCommand = "git clone \(package.gitPath) \(package.repoPath) && cd \(package.repoPath) && git checkout --recurse-submodules \(package.version)"
+            cloneCommand = "git clone \(package.gitPath) \(package.repoPath) && cd \(package.repoPath) && git checkout \(package.version) && git submodule update --init --recursive"
         } else {
             cloneCommand = "git clone --depth 1 --recurse-submodules -b \(package.version) \(package.gitPath) \(package.repoPath)"
         }


### PR DESCRIPTION
Adds git submodule support, this allows Mint to install https://github.com/apple/swift-protobuf.

I considered adding this to the tests but it would increase how long they take to run substantially.

I've left `Allow edits by maintainers` on so you can tweak this if needed @yonaskolb 😄 